### PR TITLE
Always try to obtain setVideoId of playlist items

### DIFF
--- a/ytmusicapi/parsers.py
+++ b/ytmusicapi/parsers.py
@@ -88,7 +88,7 @@ def parse_albums(results):
     return albums
 
 
-def parse_playlist_items(results, owned=False):
+def parse_playlist_items(results):
     songs = []
     count = 1
     for result in results:
@@ -100,21 +100,21 @@ def parse_playlist_items(results, owned=False):
         try:
             # if playlist is not owned, the playlist item can't be interacted with
             videoId = setVideoId = None
-            if owned:
-                for item in nav(data, MENU_ITEMS):
-                    if 'menuServiceItemRenderer' in item and 'playlistEditEndpoint' in nav(
-                            item, MENU_SERVICE):
-                        setVideoId = nav(
-                            item, MENU_SERVICE)['playlistEditEndpoint']['actions'][0]['setVideoId']
-                        videoId = nav(
-                            item,
-                            MENU_SERVICE)['playlistEditEndpoint']['actions'][0]['removedVideoId']
-                        break
-            else:
-                # if item is not playable, there is no videoId
-                if 'playNavigationEndpoint' in nav(data, PLAY_BUTTON):
+
+            # if item is not playable, there is no videoId
+            if 'playNavigationEndpoint' in nav(data, PLAY_BUTTON):
+                videoId = nav(
+                    data, PLAY_BUTTON)['playNavigationEndpoint']['watchEndpoint']['videoId']
+
+            for item in nav(data, MENU_ITEMS):
+                if 'menuServiceItemRenderer' in item and 'playlistEditEndpoint' in nav(
+                        item, MENU_SERVICE):
+                    setVideoId = nav(
+                        item, MENU_SERVICE)['playlistEditEndpoint']['actions'][0]['setVideoId']
                     videoId = nav(
-                        data, PLAY_BUTTON)['playNavigationEndpoint']['watchEndpoint']['videoId']
+                        item,
+                        MENU_SERVICE)['playlistEditEndpoint']['actions'][0]['removedVideoId']
+                    break
 
             title = get_item_text(data, 0)
 
@@ -135,7 +135,7 @@ def parse_playlist_items(results, owned=False):
             song = {'videoId': videoId, 'title': title, 'artists': artists, 'album': album}
             if duration:
                 song['duration'] = duration
-            if owned:
+            if setVideoId:
                 song['setVideoId'] = setVideoId
 
             songs.append(song)

--- a/ytmusicapi/ytmusic.py
+++ b/ytmusicapi/ytmusic.py
@@ -737,13 +737,13 @@ class YTMusic:
         playlist['tracks'] = []
 
         if song_count > 0:
-            playlist['tracks'].extend(parse_playlist_items(results['contents'], own_playlist))
+            playlist['tracks'].extend(parse_playlist_items(results['contents']))
             songs_to_get = min(limit, song_count)
 
             if 'continuations' in results:
                 request_func = lambda additionalParams: self.__send_request(
                     endpoint, body, additionalParams)
-                parse_func = lambda contents: parse_playlist_items(contents, own_playlist)
+                parse_func = lambda contents: parse_playlist_items(contents)
                 playlist['tracks'].extend(
                     get_continuations(results, 'musicPlaylistShelfContinuation', 100, songs_to_get,
                                       request_func, parse_func))


### PR DESCRIPTION
Collaborative playlists allow collaborators to remove items, so the items have `setVideoId` assigned, but the playlists themselves do not appear editable - they are not owned.

Make it so that attempt to obtain `setVideoId` is performed also in such cases.

Fixes #23.