### PR TITLE
Fix KeyError when artist doesn't have subscribers count

### DIFF
--- a/ytmusicapi/mixins/browsing.py
+++ b/ytmusicapi/mixins/browsing.py
@@ -190,7 +190,7 @@ class BrowsingMixin:
         subscription_button = header['subscriptionButton']['subscribeButtonRenderer']
         artist['channelId'] = subscription_button['channelId']
         artist['subscribers'] = nav(subscription_button,
-                                    ['subscriberCountText', 'runs', 0, 'text'])
+                                    ['subscriberCountText', 'runs', 0, 'text'], True)
         artist['subscribed'] = subscription_button['subscribed']
         artist['thumbnails'] = nav(header, THUMBNAILS)
         artist['songs'] = {'browseId': None}

--- a/ytmusicapi/parsers.py
+++ b/ytmusicapi/parsers.py
@@ -322,11 +322,17 @@ def get_continuations(results, continuation_type, per_page, limit, request_func,
     return items
 
 
-def nav(root, items):
+def nav(root, items, none_if_absent=False):
     """Access a nested object in root by item sequence."""
-    for k in items:
-        root = root[k]
-    return root
+    try:
+        for k in items:
+            root = root[k]
+        return root
+    except KeyError as err:
+        if none_if_absent:
+            return None
+        else:
+            raise err;   
 
 
 def find_object_by_key(object_list, key, nested=None, is_key=False):


### PR DESCRIPTION
Some artists, for example https://music.youtube.com/channel/UCl69tOzr3a_ZjKB6SuCivVA doesn't have subscriber count. It raises following exception
```
  Traceback (most recent call last):
    File "/var/www/music/ytmusicapi/ytmusic.py", line 14, in <module>
      result = ytmusic.get_artist(sys.argv[2])
    File "/usr/local/lib/python3.6/dist-packages/ytmusicapi/helpers.py", line 62, in _impl
      return method(self, *method_args, **method_kwargs)
    File "/usr/local/lib/python3.6/dist-packages/ytmusicapi/ytmusic.py", line 318, in get_artist
      ['subscriberCountText', 'runs', 0, 'text'])
    File "/usr/local/lib/python3.6/dist-packages/ytmusicapi/parsers.py", line 330, in nav
      root = root[k]
  KeyError: 'subscriberCountText'
```
This PR fixes it.