### PR TITLE
Fix for artists without like buttons

### DIFF
--- a/ytmusicapi/mixins/browsing.py
+++ b/ytmusicapi/mixins/browsing.py
@@ -190,7 +190,7 @@ class BrowsingMixin:
         subscription_button = header['subscriptionButton']['subscribeButtonRenderer']
         artist['channelId'] = subscription_button['channelId']
         artist['subscribers'] = nav(subscription_button,
-                                    ['subscriberCountText', 'runs', 0, 'text'])
+                                    ['subscriberCountText', 'runs', 0, 'text'], True)
         artist['subscribed'] = subscription_button['subscribed']
         artist['thumbnails'] = nav(header, THUMBNAILS)
         artist['songs'] = {'browseId': None}

--- a/ytmusicapi/parsers.py
+++ b/ytmusicapi/parsers.py
@@ -322,11 +322,17 @@ def get_continuations(results, continuation_type, per_page, limit, request_func,
     return items
 
 
-def nav(root, items):
+def nav(root, items, none_if_absent=False):
     """Access a nested object in root by item sequence."""
-    for k in items:
-        root = root[k]
-    return root
+    try:
+        for k in items:
+            root = root[k]
+        return root
+    except KeyError as err:
+        if none_if_absent:
+            return None
+        else:
+            raise err;   
 
 
 def find_object_by_key(object_list, key, nested=None, is_key=False):

--- a/ytmusicapi/parsers.py
+++ b/ytmusicapi/parsers.py
@@ -188,8 +188,8 @@ def parse_playlist_items(results):
                         break
 
                 if 'menu' in data:
-                    like = nav(data, MENU_LIKE_STATUS)
-
+                    like = nav(data, MENU_LIKE_STATUS, True)
+    
             title = get_item_text(data, 0)
             if title == 'Song deleted':
                 continue


### PR DESCRIPTION
Some artists doesn't have like buttons for songs list, for example https://music.youtube.com/channel/UC4HYnYJf1UxodkVFQkUHF9A. Because of this, get_artist() returns empty song list, and pollutes stdout with messages
```
Item 2: 'topLevelButtons'
Item 3: 'topLevelButtons'
Item 4: 'topLevelButtons'
Item 5: 'topLevelButtons'
Item 6: 'topLevelButtons'
```
This PR fixes it. It depends on previous PR.