### PR TITLE
Case-insensitive header parsing in setup()

### DIFF
--- a/ytmusicapi/setup.py
+++ b/ytmusicapi/setup.py
@@ -21,13 +21,14 @@ def setup(filepath=None, headers_raw=None):
         contents = headers_raw.split('\n')
 
     required_headers = ["Cookie"]
+    required_headers_lower = {v.lower(): v for v in required_headers }
     try:
         headers = {}
         for content in contents:
             header = content.split(': ')
-            key = header[0]
-            if key in required_headers:
-                headers[key] = ': '.join(header[1:])
+            key = header[0].lower()
+            if key in required_headers_lower:
+                headers[required_headers_lower[key]] = ': '.join(header[1:])
 
     except Exception as e:
         raise Exception("Error parsing your input, please try again. Full error: " + str(e))


### PR DESCRIPTION
In Chrome DevTools, request header names are shown in lowercase and passing them makes current `YTMusic.setup()` fail with:
```
$ cat testrun.py
import ytmusicapi
ytmusicapi.YTMusic.setup('yt.json')
$ python testrun.py
Please paste the request headers from Firefox and press Ctrl-D to continue:
cookie: VISITOR_INFO1_LIVE=[masked]
Traceback (most recent call last):
  File "testrun.py", line 3, in <module>
    ytmusicapi.YTMusic.setup('yt.json')
  File "/home/sarisia/repo/github.com/sigma67/ytmusicapi/ytmusicapi/ytmusic.py", line 129, in setup
    return setup(filepath, headers_raw)
  File "/home/sarisia/repo/github.com/sigma67/ytmusicapi/ytmusicapi/setup.py", line 37, in setup
    raise Exception(
Exception: The following entries are missing in your headers: Cookie. Please try a different request (such as /browse) and make sure you are logged in.
```

In HTTP specs, [request header names are case-insensitive](https://stackoverflow.com/questions/5258977/are-http-headers-case-sensitive) so this PR will fix `YTMusic.setup()` to try to parse headers with lowercase.

The case for `Cookie` in output JSON will remain unchanged in order to keep compatibility with previous releases.
