### PR TITLE
Return empty list if no songs are uploaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ docs/build
 **.mp3
 .coverage
 **/__pycache__/
+venv*/
+*.egg-info/

--- a/tests/test.py
+++ b/tests/test.py
@@ -134,7 +134,8 @@ class TestYTMusic(unittest.TestCase):
     @unittest.skip
     def test_remove_history_items(self):
         songs = youtube_auth.get_history()
-        response = youtube_auth.remove_history_items([songs[0]['feedbackToken'], songs[1]['feedbackToken']])
+        response = youtube_auth.remove_history_items(
+            [songs[0]['feedbackToken'], songs[1]['feedbackToken']])
         self.assertIn('feedbackResponses', response)
 
     def test_rate_song(self):
@@ -211,9 +212,19 @@ class TestYTMusic(unittest.TestCase):
         results = youtube_auth.get_library_upload_songs(100)
         self.assertGreater(len(results), 25)
 
+    @unittest.skip("Must not have any uploaded songs to pass")
+    def test_get_library_upload_songs_empty(self):
+        results = youtube_auth.get_library_upload_songs(100)
+        self.assertEquals(len(results), 0)
+
     def test_get_library_upload_albums(self):
         results = youtube_auth.get_library_upload_albums(50)
         self.assertGreater(len(results), 25)
+
+    @unittest.skip("Must not have any uploaded albums to pass")
+    def test_get_library_upload_albums_empty(self):
+        results = youtube_auth.get_library_upload_albums(100)
+        self.assertEquals(len(results), 0)
 
     def test_get_library_upload_artists(self):
         results = youtube_auth.get_library_upload_artists(50)

--- a/tests/test.py
+++ b/tests/test.py
@@ -230,6 +230,11 @@ class TestYTMusic(unittest.TestCase):
         results = youtube_auth.get_library_upload_artists(50)
         self.assertGreater(len(results), 25)
 
+    @unittest.skip("Must not have any uploaded artsts to pass")
+    def test_get_library_upload_artists_empty(self):
+        results = youtube_auth.get_library_upload_artists(100)
+        self.assertEquals(len(results), 0)
+
     def test_upload_song(self):
         self.assertRaises(Exception, youtube_auth.upload_song, 'song.wav')
         response = youtube_auth.upload_song(config['uploads']['file'])

--- a/ytmusicapi/mixins/uploads.py
+++ b/ytmusicapi/mixins/uploads.py
@@ -95,7 +95,11 @@ class UploadsMixin:
         response = self._send_request(endpoint, body)
         results = find_object_by_key(nav(response, SINGLE_COLUMN_TAB + SECTION_LIST),
                                      'itemSectionRenderer')
-        results = nav(results, ITEM_SECTION)['musicShelfRenderer']
+        results = nav(results, ITEM_SECTION)
+        if 'musicShelfRenderer' not in results:
+            return []
+        else:
+            results = results['musicShelfRenderer']
         artists = parse_artists(results['contents'], True)
 
         if 'continuations' in results:

--- a/ytmusicapi/mixins/uploads.py
+++ b/ytmusicapi/mixins/uploads.py
@@ -33,7 +33,12 @@ class UploadsMixin:
         response = self._send_request(endpoint, body)
         results = find_object_by_key(nav(response, SINGLE_COLUMN_TAB + SECTION_LIST),
                                      'itemSectionRenderer')
-        results = nav(results, ITEM_SECTION)['musicShelfRenderer']
+        results = nav(results, ITEM_SECTION)
+        if 'musicShelfRenderer' not in results:
+            return []
+        else:
+            results = results['musicShelfRenderer']
+
         songs = []
 
         songs.extend(parse_uploaded_items(results['contents'][1:]))


### PR DESCRIPTION
fixes #71 
Used the same error checking logic as in get_library_upload_albums().

I wanted some unit tests so I created tests that verify an empty list is returned for these functions, But of course they assume that your upload library is empty, so I set them to be skipped. I can delete them if you think they're unnecessary, but I wanted to show that I used them to verify my code.

Updated the .gitignore with a couple standard python ignores that were showing as diffs for me.