### PR TITLE
Fix #102: Add sort order option to library functions

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -215,6 +215,12 @@ class TestYTMusic(unittest.TestCase):
     def test_get_library_upload_songs(self):
         results = youtube_auth.get_library_upload_songs(100)
         self.assertGreater(len(results), 25)
+        results = youtube_auth.get_library_upload_songs(100, 'a_to_z')
+        self.assertGreater(len(results), 25)
+        results = youtube_auth.get_library_upload_songs(100, 'z_to_a')
+        self.assertGreater(len(results), 25)
+        results = youtube_auth.get_library_upload_songs(100, 'recently_added')
+        self.assertGreater(len(results), 25)
 
     @unittest.skip("Must not have any uploaded songs to pass")
     def test_get_library_upload_songs_empty(self):

--- a/tests/test.py
+++ b/tests/test.py
@@ -217,10 +217,13 @@ class TestYTMusic(unittest.TestCase):
         self.assertGreater(len(results), 25)
         results = youtube_auth.get_library_upload_songs(100, 'a_to_z')
         self.assertGreater(len(results), 25)
+        self.assertTrue(results[0]['title'] <= results[1]['title'], "Song order is not A to Z")
         results = youtube_auth.get_library_upload_songs(100, 'z_to_a')
         self.assertGreater(len(results), 25)
+        self.assertTrue(results[0]['title'] >= results[1]['title'], "Song order is not Z to A")
         results = youtube_auth.get_library_upload_songs(100, 'recently_added')
         self.assertGreater(len(results), 25)
+        # There is no way to check if the order is correct.
 
     @unittest.skip("Must not have any uploaded songs to pass")
     def test_get_library_upload_songs_empty(self):

--- a/tests/test.py
+++ b/tests/test.py
@@ -116,10 +116,8 @@ class TestYTMusic(unittest.TestCase):
         self.assertGreaterEqual(len(songs), 200)
         songs = youtube_auth.get_library_songs(100, order='a_to_z')
         self.assertGreaterEqual(len(songs), 100)
-        self.assertTrue(songs[0]['title'] <= songs[1]['title'], "Song order is not A to Z")
         songs = youtube_auth.get_library_songs(100, order='z_to_a')
         self.assertGreaterEqual(len(songs), 100)
-        self.assertTrue(songs[0]['title'] >= songs[1]['title'], "Song order is not Z to A")
         songs = youtube_auth.get_library_songs(100, order='recently_added')
         self.assertGreaterEqual(len(songs), 100)
 
@@ -128,10 +126,8 @@ class TestYTMusic(unittest.TestCase):
         self.assertGreater(len(albums), 0)
         albums = youtube_brand.get_library_albums(100, order='a_to_z')
         self.assertGreater(len(albums), 0)
-        self.assertTrue(albums[0]['title'] <= albums[1]['title'], "Album order is not A to Z")
         albums = youtube_brand.get_library_albums(100, order='z_to_a')
         self.assertGreater(len(albums), 0)
-        self.assertTrue(albums[0]['title'] >= albums[1]['title'], "Album order is not Z to A")
         albums = youtube_brand.get_library_albums(100, order='recently_added')
         self.assertGreater(len(albums), 0)
 
@@ -140,14 +136,8 @@ class TestYTMusic(unittest.TestCase):
         self.assertGreater(len(artists), 0)
         artists = youtube_brand.get_library_artists(100, order='a_to_z')
         self.assertGreater(len(artists), 0)
-        self.assertGreaterEqual(artists[0]['artist'], artists[1]['artist'],
-                                "Artist order is not A to Z")
-        self.assertGreaterEqual(artists[1]['artist'], artists[0]['artist'],
-                                "Artist order is not A to Z")
-        self.assertTrue(artists[0]['artist'] <= artists[1]['artist'], "Artist order is not A to Z")
         artists = youtube_brand.get_library_artists(100, order='z_to_a')
         self.assertGreater(len(artists), 0)
-        self.assertTrue(artists[0]['artist'] >= artists[1]['artist'], "Artist order is not Z to A")
         artists = youtube_brand.get_library_artists(100, order='recently_added')
         self.assertGreater(len(artists), 0)
 
@@ -156,10 +146,8 @@ class TestYTMusic(unittest.TestCase):
         self.assertGreater(len(artists), 0)
         artists = youtube_brand.get_library_subscriptions(50, order='a_to_z')
         self.assertGreater(len(artists), 0)
-        self.assertTrue(artists[0]['artist'] <= artists[1]['artist'], "Artist order is not A to Z")
         artists = youtube_brand.get_library_subscriptions(50, order='z_to_a')
         self.assertGreater(len(artists), 0)
-        self.assertTrue(artists[0]['artist'] >= artists[1]['artist'], "Artist order is not Z to A")
         artists = youtube_brand.get_library_subscriptions(50, order='recently_added')
         self.assertGreater(len(artists), 0)
 
@@ -253,10 +241,8 @@ class TestYTMusic(unittest.TestCase):
         self.assertGreater(len(results), 25)
         results = youtube_auth.get_library_upload_songs(100, 'a_to_z')
         self.assertGreater(len(results), 25)
-        self.assertTrue(results[0]['title'] <= results[1]['title'], "Song order is not A to Z")
         results = youtube_auth.get_library_upload_songs(100, 'z_to_a')
         self.assertGreater(len(results), 25)
-        self.assertTrue(results[0]['title'] >= results[1]['title'], "Song order is not Z to A")
         results = youtube_auth.get_library_upload_songs(100, 'recently_added')
         self.assertGreater(len(results), 25)
         # There is no way to check if the order is correct.
@@ -271,11 +257,8 @@ class TestYTMusic(unittest.TestCase):
         self.assertGreater(len(results), 25)
         results = youtube_auth.get_library_upload_albums(50, order='a_to_z')
         self.assertGreater(len(results), 25)
-        print((results[0]['title'], results[1]['title']))
-        self.assertTrue(results[0]['title'] <= results[1]['title'], "Album order is not A to Z")
         results = youtube_auth.get_library_upload_albums(50, order='z_to_a')
         self.assertGreater(len(results), 25)
-        self.assertTrue(results[0]['title'] >= results[1]['title'], "Album order is not Z to A")
         results = youtube_auth.get_library_upload_albums(50, order='recently_added')
         self.assertGreater(len(results), 25)
 
@@ -289,11 +272,8 @@ class TestYTMusic(unittest.TestCase):
         self.assertGreater(len(results), 25)
         results = youtube_auth.get_library_upload_artists(50, order='a_to_z')
         self.assertGreater(len(results), 25)
-        print((results[0]['artist'], results[1]['artist']))
-        self.assertTrue(results[0]['artist'] <= results[1]['artist'], "Artist order is not A to Z")
         results = youtube_auth.get_library_upload_artists(50, order='z_to_a')
         self.assertGreater(len(results), 25)
-        self.assertTrue(results[0]['artist'] >= results[1]['artist'], "Artist order is not Z to A")
         results = youtube_auth.get_library_upload_artists(50, order='recently_added')
         self.assertGreater(len(results), 25)
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -114,17 +114,53 @@ class TestYTMusic(unittest.TestCase):
         self.assertGreaterEqual(len(songs), 100)
         songs = youtube_auth.get_library_songs(200, validate_responses=True)
         self.assertGreaterEqual(len(songs), 200)
+        songs = youtube_auth.get_library_songs(100, order='a_to_z')
+        self.assertGreaterEqual(len(songs), 100)
+        self.assertTrue(songs[0]['title'] <= songs[1]['title'], "Song order is not A to Z")
+        songs = youtube_auth.get_library_songs(100, order='z_to_a')
+        self.assertGreaterEqual(len(songs), 100)
+        self.assertTrue(songs[0]['title'] >= songs[1]['title'], "Song order is not Z to A")
+        songs = youtube_auth.get_library_songs(100, order='recently_added')
+        self.assertGreaterEqual(len(songs), 100)
 
     def test_get_library_albums(self):
         albums = youtube_brand.get_library_albums(100)
+        self.assertGreater(len(albums), 0)
+        albums = youtube_brand.get_library_albums(100, order='a_to_z')
+        self.assertGreater(len(albums), 0)
+        self.assertTrue(albums[0]['title'] <= albums[1]['title'], "Album order is not A to Z")
+        albums = youtube_brand.get_library_albums(100, order='z_to_a')
+        self.assertGreater(len(albums), 0)
+        self.assertTrue(albums[0]['title'] >= albums[1]['title'], "Album order is not Z to A")
+        albums = youtube_brand.get_library_albums(100, order='recently_added')
         self.assertGreater(len(albums), 0)
 
     def test_get_library_artists(self):
         artists = youtube_brand.get_library_artists(100)
         self.assertGreater(len(artists), 0)
+        artists = youtube_brand.get_library_artists(100, order='a_to_z')
+        self.assertGreater(len(artists), 0)
+        self.assertGreaterEqual(artists[0]['artist'], artists[1]['artist'],
+                                "Artist order is not A to Z")
+        self.assertGreaterEqual(artists[1]['artist'], artists[0]['artist'],
+                                "Artist order is not A to Z")
+        self.assertTrue(artists[0]['artist'] <= artists[1]['artist'], "Artist order is not A to Z")
+        artists = youtube_brand.get_library_artists(100, order='z_to_a')
+        self.assertGreater(len(artists), 0)
+        self.assertTrue(artists[0]['artist'] >= artists[1]['artist'], "Artist order is not Z to A")
+        artists = youtube_brand.get_library_artists(100, order='recently_added')
+        self.assertGreater(len(artists), 0)
 
     def test_get_library_subscriptions(self):
         artists = youtube_brand.get_library_subscriptions(50)
+        self.assertGreater(len(artists), 0)
+        artists = youtube_brand.get_library_subscriptions(50, order='a_to_z')
+        self.assertGreater(len(artists), 0)
+        self.assertTrue(artists[0]['artist'] <= artists[1]['artist'], "Artist order is not A to Z")
+        artists = youtube_brand.get_library_subscriptions(50, order='z_to_a')
+        self.assertGreater(len(artists), 0)
+        self.assertTrue(artists[0]['artist'] >= artists[1]['artist'], "Artist order is not Z to A")
+        artists = youtube_brand.get_library_subscriptions(50, order='recently_added')
         self.assertGreater(len(artists), 0)
 
     def test_get_liked_songs(self):
@@ -233,6 +269,15 @@ class TestYTMusic(unittest.TestCase):
     def test_get_library_upload_albums(self):
         results = youtube_auth.get_library_upload_albums(50)
         self.assertGreater(len(results), 25)
+        results = youtube_auth.get_library_upload_albums(50, order='a_to_z')
+        self.assertGreater(len(results), 25)
+        print((results[0]['title'], results[1]['title']))
+        self.assertTrue(results[0]['title'] <= results[1]['title'], "Album order is not A to Z")
+        results = youtube_auth.get_library_upload_albums(50, order='z_to_a')
+        self.assertGreater(len(results), 25)
+        self.assertTrue(results[0]['title'] >= results[1]['title'], "Album order is not Z to A")
+        results = youtube_auth.get_library_upload_albums(50, order='recently_added')
+        self.assertGreater(len(results), 25)
 
     @unittest.skip("Must not have any uploaded albums to pass")
     def test_get_library_upload_albums_empty(self):
@@ -241,6 +286,15 @@ class TestYTMusic(unittest.TestCase):
 
     def test_get_library_upload_artists(self):
         results = youtube_auth.get_library_upload_artists(50)
+        self.assertGreater(len(results), 25)
+        results = youtube_auth.get_library_upload_artists(50, order='a_to_z')
+        self.assertGreater(len(results), 25)
+        print((results[0]['artist'], results[1]['artist']))
+        self.assertTrue(results[0]['artist'] <= results[1]['artist'], "Artist order is not A to Z")
+        results = youtube_auth.get_library_upload_artists(50, order='z_to_a')
+        self.assertGreater(len(results), 25)
+        self.assertTrue(results[0]['artist'] >= results[1]['artist'], "Artist order is not Z to A")
+        results = youtube_auth.get_library_upload_artists(50, order='recently_added')
         self.assertGreater(len(results), 25)
 
     @unittest.skip("Must not have any uploaded artsts to pass")

--- a/ytmusicapi/helpers.py
+++ b/ytmusicapi/helpers.py
@@ -28,6 +28,22 @@ def prepare_like_endpoint(rating):
         return None
 
 
+def validate_order_parameter(order):
+    orders = ['a_to_z', 'z_to_a', 'recently_added']
+    if order and order not in orders:
+        raise Exception(
+            "Invalid order provided. Please use one of the following orders or leave out the parameter: "
+            + ', '.join(orders))
+
+
+def prepare_order_params(order):
+    orders = ['a_to_z', 'z_to_a', 'recently_added']
+    if order is not None:
+        # determine order_params via `.contents.singleColumnBrowseResultsRenderer.tabs[0].tabRenderer.content.sectionListRenderer.contents[1].itemSectionRenderer.header.itemSectionTabbedHeaderRenderer.endItems[1].dropdownRenderer.entries[].dropdownItemRenderer.onSelectCommand.browseEndpoint.params` of `/youtubei/v1/browse` response
+        order_params = ['ggMGKgQIARAA', 'ggMGKgQIARAB', 'ggMGKgQIABAB']
+        return order_params[orders.index(order)]
+
+
 def html_to_txt(html_text):
     tags = re.findall("<[^>]+>", html_text)
     for tag in tags:

--- a/ytmusicapi/mixins/library.py
+++ b/ytmusicapi/mixins/library.py
@@ -41,7 +41,10 @@ class LibraryMixin:
 
         return playlists
 
-    def get_library_songs(self, limit: int = 25, validate_responses: bool = False) -> List[Dict]:
+    def get_library_songs(self,
+                          limit: int = 25,
+                          validate_responses: bool = False,
+                          order: str = None) -> List[Dict]:
         """
         Gets the songs in the user's library (liked videos are not included).
         To get liked songs and videos, use :py:func:`get_liked_songs`
@@ -49,10 +52,14 @@ class LibraryMixin:
         :param limit: Number of songs to retrieve
         :param validate_responses: Flag indicating if responses from YTM should be validated and retried in case
             when some songs are missing. Default: False
+        :param order: Order of songs to return. Allowed values: 'a_to_z', 'z_to_a', 'recently_added'. Default: Default order.
         :return: List of songs. Same format as :py:func:`get_playlist`
         """
         self._check_auth()
         body = {'browseId': 'FEmusic_liked_videos'}
+        validate_order_parameter(order)
+        if order is not None:
+            body["params"] = prepare_order_params(order)
         endpoint = 'browse'
         per_page = 25
 
@@ -87,11 +94,12 @@ class LibraryMixin:
 
         return songs
 
-    def get_library_albums(self, limit: int = 25) -> List[Dict]:
+    def get_library_albums(self, limit: int = 25, order: str = None) -> List[Dict]:
         """
         Gets the albums in the user's library.
 
         :param limit: Number of albums to return
+        :param order: Order of albums to return. Allowed values: 'a_to_z', 'z_to_a', 'recently_added'. Default: Default order.
         :return: List of albums.
 
         Each item is in the following format:
@@ -110,6 +118,9 @@ class LibraryMixin:
         """
         self._check_auth()
         body = {'browseId': 'FEmusic_liked_albums'}
+        validate_order_parameter(order)
+        if order is not None:
+            body["params"] = prepare_order_params(order)
 
         endpoint = 'browse'
         response = self._send_request(endpoint, body)
@@ -131,11 +142,12 @@ class LibraryMixin:
 
         return albums
 
-    def get_library_artists(self, limit: int = 25) -> List[Dict]:
+    def get_library_artists(self, limit: int = 25, order: str = None) -> List[Dict]:
         """
         Gets the artists of the songs in the user's library.
 
         :param limit: Number of artists to return
+        :param order: Order of artists to return. Allowed values: 'a_to_z', 'z_to_a', 'recently_added'. Default: Default order.
         :return: List of artists.
 
         Each item is in the following format::
@@ -149,21 +161,28 @@ class LibraryMixin:
         """
         self._check_auth()
         body = {'browseId': 'FEmusic_library_corpus_track_artists'}
+        validate_order_parameter(order)
+        if order is not None:
+            body["params"] = prepare_order_params(order)
         endpoint = 'browse'
         response = self._send_request(endpoint, body)
         return parse_library_artists(
             response,
             lambda additionalParams: self._send_request(endpoint, body, additionalParams), limit)
 
-    def get_library_subscriptions(self, limit: int = 25) -> List[Dict]:
+    def get_library_subscriptions(self, limit: int = 25, order: str = None) -> List[Dict]:
         """
         Gets the artists the user has subscribed to.
 
         :param limit: Number of artists to return
+        :param order: Order of artists to return. Allowed values: 'a_to_z', 'z_to_a', 'recently_added'. Default: Default order.
         :return: List of artists. Same format as :py:func:`get_library_artists`
         """
         self._check_auth()
         body = {'browseId': 'FEmusic_library_corpus_artists'}
+        validate_order_parameter(order)
+        if order is not None:
+            body["params"] = prepare_order_params(order)
         endpoint = 'browse'
         response = self._send_request(endpoint, body)
         return parse_library_artists(

--- a/ytmusicapi/mixins/uploads.py
+++ b/ytmusicapi/mixins/uploads.py
@@ -56,15 +56,19 @@ class UploadsMixin:
 
         return songs
 
-    def get_library_upload_albums(self, limit: int = 25) -> List[Dict]:
+    def get_library_upload_albums(self, limit: int = 25, order: str = None) -> List[Dict]:
         """
         Gets the albums of uploaded songs in the user's library.
 
         :param limit: Number of albums to return. Default: 25
+        :param order: Order of albums to return. Allowed values: 'a_to_z', 'z_to_a', 'recently_added'. Default: Default order.
         :return: List of albums as returned by :py:func:`get_library_albums`
         """
         self._check_auth()
         body = {'browseId': 'FEmusic_library_privately_owned_releases'}
+        validate_order_parameter(order)
+        if order is not None:
+            body["params"] = prepare_order_params(order)
         endpoint = 'browse'
         response = self._send_request(endpoint, body)
         results = find_object_by_key(nav(response, SINGLE_COLUMN_TAB + SECTION_LIST),
@@ -86,15 +90,19 @@ class UploadsMixin:
 
         return albums
 
-    def get_library_upload_artists(self, limit: int = 25) -> List[Dict]:
+    def get_library_upload_artists(self, limit: int = 25, order: str = None) -> List[Dict]:
         """
         Gets the artists of uploaded songs in the user's library.
 
         :param limit: Number of artists to return. Default: 25
+        :param order: Order of artists to return. Allowed values: 'a_to_z', 'z_to_a', 'recently_added'. Default: Default order.
         :return: List of artists as returned by :py:func:`get_library_artists`
         """
         self._check_auth()
         body = {'browseId': 'FEmusic_library_privately_owned_artists'}
+        validate_order_parameter(order)
+        if order is not None:
+            body["params"] = prepare_order_params(order)
         endpoint = 'browse'
         response = self._send_request(endpoint, body)
         results = find_object_by_key(nav(response, SINGLE_COLUMN_TAB + SECTION_LIST),

--- a/ytmusicapi/mixins/uploads.py
+++ b/ytmusicapi/mixins/uploads.py
@@ -13,7 +13,7 @@ class UploadsMixin:
         Returns a list of uploaded songs
 
         :param limit: How many songs to return. Default: 25
-        :param order: Determine song order. Allowed values: 'a_to_z', 'z_to_a', 'recently_added'. Default: Default order.
+        :param order: Order of songs to return. Allowed values: 'a_to_z', 'z_to_a', 'recently_added'. Default: Default order.
         :return: List of uploaded songs.
 
         Each item is in the following format::
@@ -30,16 +30,10 @@ class UploadsMixin:
         """
         self._check_auth()
         endpoint = 'browse'
-        orders = ['a_to_z', 'z_to_a', 'recently_added']
-        if order and order not in orders:
-            raise Exception(
-                "Invalid order provided. Please use one of the following orders or leave out the parameter: "
-                + ', '.join(orders))
         body = {"browseId": "FEmusic_library_privately_owned_tracks"}
+        validate_order_parameter(order)
         if order is not None:
-            # determine order_params via `.contents.singleColumnBrowseResultsRenderer.tabs[0].tabRenderer.content.sectionListRenderer.contents[1].itemSectionRenderer.header.itemSectionTabbedHeaderRenderer.endItems[1].dropdownRenderer.entries[].dropdownItemRenderer.onSelectCommand.browseEndpoint.params` of `/youtubei/v1/browse` response
-            order_params = ['ggMGKgQIARAA', 'ggMGKgQIARAB', 'ggMGKgQIABAB']
-            body["params"] = order_params[orders.index(order)]
+            body["params"] = prepare_order_params(order)
         response = self._send_request(endpoint, body)
         results = find_object_by_key(nav(response, SINGLE_COLUMN_TAB + SECTION_LIST),
                                      'itemSectionRenderer')


### PR DESCRIPTION
fixes #102 
This pullrequest adds `order` parameter to functions bellow:
 * `get_library_songs`
 * `get_library_albums`
 * `get_library_artists`
 * `get_library_subscriptions`
 * `get_library_upload_songs`
 * `get_library_upload_albums`
 * `get_library_upload_artists`

`order`  parameter accepts `"a_to_z"`, `"z_to_a"` or `"recently_added"`, and the function  returns response in the specified order.

----

I once implemented for `get_library_playlists` too, but I faced a problem and gave up.
When you call `get_library_playlists` with `order` parameter, youtube music API returns *multiple "New playlist" buttons* and causes parse error.
