### PR TITLE
Fix documents: Update URL to get brand's user_id

### DIFF
--- a/ytmusicapi/ytmusic.py
+++ b/ytmusicapi/ytmusic.py
@@ -40,7 +40,7 @@ class YTMusic(BrowsingMixin, WatchMixin, LibraryMixin, PlaylistsMixin, UploadsMi
         :param user: Optional. Specify a user ID string to use in requests.
           This is needed if you want to send requests on behalf of a brand account.
           Otherwise the default account is used. You can retrieve the user ID
-          by going to https://myaccount.google.com and selecting your brand account.
+          by going to https://myaccount.google.com/brandaccounts and selecting your brand account.
           The user ID will be in the URL: https://myaccount.google.com/b/user_id/
         :param proxies: Optional. Proxy configuration in requests_ format_.
 


### PR DESCRIPTION
This correct URL  should be https://myaccount.google.com/brandaccounts

<img width="731" alt="Screen Shot 2020-11-27 at 2 31 50 PM" src="https://user-images.githubusercontent.com/1745000/100439807-73854c80-30bd-11eb-805f-151bbc140235.png">
