### PR TITLE
Add radio/Shuffle ID to search results

### DIFF
--- a/ytmusicapi/parsers/browsing.py
+++ b/ytmusicapi/parsers/browsing.py
@@ -71,7 +71,8 @@ class Parser:
                         search_result['feedbackTokens'] = parse_song_menu_tokens(toggle_menu)
 
             elif resultType in ['video']:
-                search_result['views'] = get_item_text(data, 1, 2 + last_artist_index).split(' ')[0]
+                search_result['views'] = get_item_text(data, 1,
+                                                       2 + last_artist_index).split(' ')[0]
                 search_result['duration'] = get_item_text(data, 1, 4 + last_artist_index, True)
 
             elif resultType in ['upload']:
@@ -112,6 +113,28 @@ class Parser:
                         if len(runs) > 2:  # date may be missing
                             search_result['releaseDate'] = runs[2]
                         search_result['resultType'] = 'album'
+
+            watch_menu = find_objects_by_key(nav(data, MENU_ITEMS), 'menuNavigationItemRenderer')
+            for item in [_x['menuNavigationItemRenderer'] for _x in watch_menu]:
+                icon = nav(item, ['icon', 'iconType'])
+                if icon == 'MUSIC_SHUFFLE':
+                    watch_key = 'shuffleId'
+                elif icon == 'MIX':
+                    watch_key = 'radioId'
+                else:
+                    # ADD_TO_PLAYLIST
+                    # ALBUM
+                    # ARTIST
+                    # SHARE
+                    continue
+
+                watch_id = nav(item, ['navigationEndpoint', 'watchPlaylistEndpoint', 'playlistId'],
+                               True)
+                if not watch_id:
+                    watch_id = nav(item, ['navigationEndpoint', 'watchEndpoint', 'playlistId'],
+                                   True)
+                if watch_id:
+                    search_result[watch_key] = watch_id
 
             search_result['thumbnails'] = nav(data, THUMBNAILS)
             search_results.append(search_result)


### PR DESCRIPTION
I wanted to be able to create streaming radio channels from search results.
This patch extracts the Shuffle and Radio playlist ids from the search results.

yapf seems to have changed an unrelated line for some reason, I can manually revert it if you like

I was unable to get all the tests to pass (even without my change), but the search tests all seem to work ok