### PR TITLE
Fix KeyError: 'runs' if album has no year

### DIFF
--- a/ytmusicapi/parsers/library.py
+++ b/ytmusicapi/parsers/library.py
@@ -48,30 +48,32 @@ def parse_albums(results):
         album['browseId'] = nav(data, TITLE + NAVIGATION_BROWSE_ID)
         album['title'] = nav(data, TITLE_TEXT)
         album['thumbnails'] = nav(data, THUMBNAIL_RENDERER)
-        run_count = len(data['subtitle']['runs'])
-        has_artists = False
-        if run_count == 1:
-            album['year'] = nav(data, SUBTITLE)
-        else:
-            album['type'] = nav(data, SUBTITLE)
-
-        if run_count == 3:
-            if nav(data, SUBTITLE2).isdigit():
-                album['year'] = nav(data, SUBTITLE2)
+        
+        if 'runs' in data['subtitle']:
+            run_count = len(data['subtitle']['runs'])
+            has_artists = False
+            if run_count == 1:
+                album['year'] = nav(data, SUBTITLE)
             else:
+                album['type'] = nav(data, SUBTITLE)
+    
+            if run_count == 3:
+                if nav(data, SUBTITLE2).isdigit():
+                    album['year'] = nav(data, SUBTITLE2)
+                else:
+                    has_artists = True
+    
+            elif run_count > 3:
+                album['year'] = nav(data, SUBTITLE3)
                 has_artists = True
-
-        elif run_count > 3:
-            album['year'] = nav(data, SUBTITLE3)
-            has_artists = True
-
-        if has_artists:
-            subtitle = data['subtitle']['runs'][2]
-            album['artists'] = []
-            album['artists'].append({
-                'name': subtitle['text'],
-                'id': nav(subtitle, NAVIGATION_BROWSE_ID, True)
-            })
+    
+            if has_artists:
+                subtitle = data['subtitle']['runs'][2]
+                album['artists'] = []
+                album['artists'].append({
+                    'name': subtitle['text'],
+                    'id': nav(subtitle, NAVIGATION_BROWSE_ID, True)
+                })
 
         albums.append(album)
 


### PR DESCRIPTION
I got following exception, when I trying to get singles list, when some singles have no year [(this artist, for example)](https://music.youtube.com/browse/UClLLt3Gfr07OVs3qgWrOWjQ)
```
Error Output:
================
Traceback (most recent call last):  
  File \"/var/www/music/python/ytmusic.py\", line 21, in <module>
    result['singles']['results'] = ytmusic.get_artist_albums(result['singles']['browseId'], result['singles']['params'])
  File \"/var/www/music/python/ytmusicapi/ytmusicapi/mixins/browsing.py\", line 334, in get_artist_albums
    albums = parse_albums(results)  
  File \"/var/www/music/python/ytmusicapi/ytmusicapi/parsers/library.py\", line 51, in parse_albums
    run_count = len(data['subtitle']['runs'])
KeyError: 'runs'
```
This PR fixes it.

Nice to see this project alive and being actively developed!