### PR TITLE
minor checks for list values to prevent errors

### DIFF
--- a/ytmusicapi/parsers/browsing.py
+++ b/ytmusicapi/parsers/browsing.py
@@ -81,8 +81,8 @@ class Parser:
                         search_result['album'] = {
                             'name': flex_items[1][2]['text'],
                             'id': nav(flex_items[1][2], NAVIGATION_BROWSE_ID)
-                        }
-                        search_result['duration'] = flex_items[1][4]['text']
+                        } if flex_items[1].count(2) else ''
+                        search_result['duration'] = flex_items[1][4]['text'] if flex_items[1].count(4) else ''
                     search_result['resultType'] = 'song'
 
                 else:  # artist or album result
@@ -95,7 +95,7 @@ class Parser:
                             run['text'] for i, run in enumerate(flex_item2['text']['runs'])
                             if i % 2 == 0
                         ]
-                        search_result['artist'] = runs[1]
+                        search_result['artist'] = runs[1] if runs.count(1) else ''
                         if len(runs) > 2:  # date may be missing
                             search_result['releaseDate'] = runs[2]
                         search_result['resultType'] = 'album'

--- a/ytmusicapi/parsers/utils.py
+++ b/ytmusicapi/parsers/utils.py
@@ -144,7 +144,7 @@ def nav(root, items, none_if_absent=False):
         if none_if_absent:
             return None
         else:
-            raise err
+            return None
 
 
 def find_object_by_key(object_list, key, nested=None, is_key=False):


### PR DESCRIPTION
This may be specific to those who have imported Google Play Music libraries into Youtube Music.  As meticulous as I have been about ensuring all songs have the minimum mp3 tags (song title , artist and genre) as well as "album" wherever possible, I have seen results come back from ytmusicapi searches on "uploads" where the artist or album is missing and cause parsers/browsing.py or parsers/utils.py throw errors.  These searches on the same terms work and return results in Youtube Music in the browser.

These minor additions ensure we're checking for values in Python list structures in some cases where they're assumed to be there.  These changes just make for more graceful performance when encountering data that is expected to be present, but may not be.