### PR TITLE
Flip re.search parameters when parsing playlist info.

### DIFF
--- a/ytmusicapi/parsers/browsing.py
+++ b/ytmusicapi/parsers/browsing.py
@@ -197,7 +197,7 @@ def parse_playlist(data):
         'playlistId': nav(data, TITLE + NAVIGATION_BROWSE_ID)[2:],
         'thumbnails': nav(data, THUMBNAIL_RENDERER)
     }
-    if len(data['subtitle']['runs']) == 3 and re.search(nav(data, SUBTITLE2), r'\d+ '):
+    if len(data['subtitle']['runs']) == 3 and re.search(r'\d+ ', nav(data, SUBTITLE2)):
         playlist['count'] = nav(data, SUBTITLE2).split(' ')[0]
     return playlist
 


### PR DESCRIPTION
They were passed backwards, so even for playlists which contain the
info, it was not being captured.