### PR TITLE
get videoType from video results

### DIFF
--- a/ytmusicapi/parsers/__init__.py
+++ b/ytmusicapi/parsers/__init__.py
@@ -24,6 +24,9 @@ PAGE_TYPE = [
 NAVIGATION_VIDEO_ID = ['navigationEndpoint', 'watchEndpoint', 'videoId']
 NAVIGATION_PLAYLIST_ID = ['navigationEndpoint', 'watchEndpoint', 'playlistId']
 NAVIGATION_WATCH_PLAYLIST_ID = ['navigationEndpoint', 'watchPlaylistEndpoint', 'playlistId']
+NAVIGATION_VIDEO_TYPE = [
+    'playNavigationEndpoint', 'watchEndpoint', 'watchEndpointMusicSupportedConfigs', 'watchEndpointMusicConfig', 'musicVideoType'
+]
 HEADER_DETAIL = ['header', 'musicDetailHeaderRenderer']
 DESCRIPTION = ['description'] + RUN_TEXT
 CAROUSEL = ['musicCarouselShelfRenderer']

--- a/ytmusicapi/parsers/browsing.py
+++ b/ytmusicapi/parsers/browsing.py
@@ -107,6 +107,7 @@ class Parser:
 
             elif resultType == 'video':
                 search_result['views'] = None
+                search_result['videoType'] = nav(data, PLAY_BUTTON + NAVIGATION_VIDEO_TYPE, True)
 
             elif resultType == 'upload':
                 browse_id = nav(data, NAVIGATION_BROWSE_ID, True)


### PR DESCRIPTION
This PR gets the `musicVideoType` param from video responses. It apparently has two possible values: `MUSIC_VIDEO_TYPE_UGC` or `MUSIC_VIDEO_TYPE_OMV`, which I guess that stands for user generated content and official music video.

When the music video is uploaded by the owner of the track, it has the value `MUSIC_VIDEO_TYPE_OMV`.