### PR TITLE
Return video type on get watch playlist

### DIFF
--- a/ytmusicapi/mixins/browsing.py
+++ b/ytmusicapi/mixins/browsing.py
@@ -155,6 +155,7 @@ class BrowsingMixin:
                   }
                 ],
                 "views": "1.4M",
+                "videoType": "MUSIC_VIDEO_TYPE_OMV",
                 "duration": "4:38",
                 "duration_seconds": 278
               },

--- a/ytmusicapi/parsers/__init__.py
+++ b/ytmusicapi/parsers/__init__.py
@@ -24,6 +24,9 @@ PAGE_TYPE = [
 NAVIGATION_VIDEO_ID = ['navigationEndpoint', 'watchEndpoint', 'videoId']
 NAVIGATION_PLAYLIST_ID = ['navigationEndpoint', 'watchEndpoint', 'playlistId']
 NAVIGATION_WATCH_PLAYLIST_ID = ['navigationEndpoint', 'watchPlaylistEndpoint', 'playlistId']
+NAVIGATION_VIDEO_TYPE = [
+    'watchEndpoint', 'watchEndpointMusicSupportedConfigs', 'watchEndpointMusicConfig', 'musicVideoType'
+]
 HEADER_DETAIL = ['header', 'musicDetailHeaderRenderer']
 DESCRIPTION = ['description'] + RUN_TEXT
 CAROUSEL = ['musicCarouselShelfRenderer']

--- a/ytmusicapi/parsers/browsing.py
+++ b/ytmusicapi/parsers/browsing.py
@@ -107,6 +107,7 @@ class Parser:
 
             elif resultType == 'video':
                 search_result['views'] = None
+                search_result['videoType'] = nav(data, PLAY_BUTTON + NAVIGATION_VIDEO_TYPE, True)
 
             elif resultType == 'upload':
                 browse_id = nav(data, NAVIGATION_BROWSE_ID, True)
@@ -142,6 +143,9 @@ class Parser:
             if resultType in ['song', 'video']:
                 search_result['videoId'] = nav(
                     data, PLAY_BUTTON + ['playNavigationEndpoint', 'watchEndpoint', 'videoId'],
+                    True)
+                search_result['videoType'] = nav(
+                    data, PLAY_BUTTON + ['playNavigationEndpoint'] + NAVIGATION_VIDEO_TYPE,
                     True)
 
             if resultType in ['song', 'video', 'album']:

--- a/ytmusicapi/parsers/watch.py
+++ b/ytmusicapi/parsers/watch.py
@@ -43,7 +43,8 @@ def parse_watch_track(data):
         'length': nav(data, ['lengthText', 'runs', 0, 'text'], True),
         'thumbnail': nav(data, THUMBNAIL),
         'feedbackTokens': feedback_tokens,
-        'likeStatus': like_status
+        'likeStatus': like_status,
+        'videoType': nav(data, ['navigationEndpoint'] + NAVIGATION_VIDEO_TYPE, True)
     }
     track.update(song_info)
     return track


### PR DESCRIPTION
This PR makes the necessary changes for videoType to be returned on the `get_watch_playlist` function.
It also updates `browsing.py` so the parameter is returned for both songs and videos, therefore we have now three possible values: `MUSIC_VIDEO_TYPE_ATV`, `MUSIC_VIDEO_TYPE_OMV` and `MUSIC_VIDEO_TYPE_UGC`.