### PR TITLE
get_artist: Don't fail on channels with only one category of content

### DIFF
--- a/ytmusicapi/mixins/browsing.py
+++ b/ytmusicapi/mixins/browsing.py
@@ -393,10 +393,6 @@ class BrowsingMixin:
         response = self._send_request(endpoint, body)
         results = nav(response, SINGLE_COLUMN_TAB + SECTION_LIST)
 
-        if len(results) == 1:
-            # not a YouTube Music Channel, a standard YouTube Channel ID with no music content was given
-            raise ValueError(f"The YouTube Channel {channelId} has no music content.")
-
         artist = {'description': None, 'views': None}
         header = response['header']['musicImmersiveHeaderRenderer']
         artist['name'] = nav(header, TITLE_TEXT)


### PR DESCRIPTION
The current check is meant to detect channels with only video content,
but it also hits small bands that for example have only released singles
so far. An example for this is "UC1uK8RT3m4nNpXmOSsFsZeg".

Since failing is not really helpful anyway (for example audiotub could still play only the sound of a channel that contains only videos),
I propose to remove the check altogether.