### PR TITLE
get_library_playlists: When limit is None, return them all.

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -208,6 +208,17 @@ class TestYTMusic(unittest.TestCase):
         playlists = self.yt_auth.get_library_playlists(50)
         self.assertGreater(len(playlists), 25)
 
+    def test_get_all_library_playlists(self):
+        current_length = len(self.yt_auth.get_library_playlists(25))
+        expected_length = current_length
+        while expected_length <= current_length:
+            expected_length = current_length + 1
+            current_length = len(self.yt_auth.get_library_playlists(expected_length))
+        expected_length -= 1
+
+        playlists = self.yt_auth.get_library_playlists(None)
+        self.assertEqual(len(playlists), expected_length)
+
     def test_get_library_songs(self):
         songs = self.yt_brand.get_library_songs(100)
         self.assertGreaterEqual(len(songs), 100)

--- a/ytmusicapi/continuations.py
+++ b/ytmusicapi/continuations.py
@@ -3,7 +3,7 @@ from ytmusicapi.navigation import nav
 
 def get_continuations(results, continuation_type, limit, request_func, parse_func, ctoken_path=""):
     items = []
-    while 'continuations' in results and len(items) < limit:
+    while 'continuations' in results and (limit is None or len(items) < limit):
         additionalParams = get_continuation_params(results, ctoken_path)
         response = request_func(additionalParams)
         if 'continuationContents' in response:

--- a/ytmusicapi/mixins/library.py
+++ b/ytmusicapi/mixins/library.py
@@ -9,7 +9,7 @@ class LibraryMixin:
         """
         Retrieves the playlists in the user's library.
 
-        :param limit: Number of playlists to retrieve
+        :param limit: Number of playlists to retrieve. `None` retrieves them all.
         :return: List of owned playlists.
 
         Each item is in the following format::
@@ -35,8 +35,9 @@ class LibraryMixin:
             request_func = lambda additionalParams: self._send_request(
                 endpoint, body, additionalParams)
             parse_func = lambda contents: parse_content_list(contents, parse_playlist)
+            remaining_limit = None if limit is None else (limit - len(playlists))
             playlists.extend(
-                get_continuations(results, 'gridContinuation', limit - len(playlists),
+                get_continuations(results, 'gridContinuation', remaining_limit,
                                   request_func, parse_func))
 
         return playlists


### PR DESCRIPTION
This PR allows the user to pass a limit of `None` to `get_library_playlists` in order to get back all of their playlists.

Addresses #275 