### PR TITLE
Remove quotes from cookies

### DIFF
--- a/ytmusicapi/helpers.py
+++ b/ytmusicapi/helpers.py
@@ -42,7 +42,7 @@ def get_visitor_id(request_func):
 
 def sapisid_from_cookie(raw_cookie):
     cookie = SimpleCookie()
-    cookie.load(raw_cookie)
+    cookie.load(raw_cookie.replace("\"", ""))
     return cookie['__Secure-3PAPISID'].value
 
 


### PR DESCRIPTION
Due to the SimpleCookie issue described [here](https://github.com/sigma67/ytmusicapi/issues/294), cookies are not properly parse when they include quotes. As the "YT_CL" cookie includes quotes, this breaks the cookie parser and throws the following exception:

```
Exception: Your cookie is missing the required value __Secure-3PAPISID
```

While one solution is to [completely re-write the cookie parser](https://github.com/django/django/commit/93a135d111c2569d88d65a3f4ad9e6d9ad291452) to fix this issue, a much simpler one may be to just remove quotes from cookies altogether. Authentication succeeds after removing the quotes from the cookies.