### PR TITLE
return videoType on playlist items

### DIFF
--- a/ytmusicapi/mixins/playlists.py
+++ b/ytmusicapi/mixins/playlists.py
@@ -88,6 +88,7 @@ class PlaylistsMixin:
                   "thumbnails": [...],
                   "isAvailable": True,
                   "isExplicit": False,
+                  "videoType": "MUSIC_VIDEO_TYPE_OMV",
                   "feedbackTokens": {
                     "add": "AB9zfpJxtvrU...",
                     "remove": "AB9zfpKTyZ..."

--- a/ytmusicapi/parsers/playlists.py
+++ b/ytmusicapi/parsers/playlists.py
@@ -66,6 +66,8 @@ def parse_playlist_items(results, menu_entries: List[List] = None):
 
             isExplicit = nav(data, BADGE_LABEL, True) is not None
 
+            videoType = nav(data, MENU_ITEMS + [0, 'menuNavigationItemRenderer', 'navigationEndpoint'] + NAVIGATION_VIDEO_TYPE, True)
+
             song = {
                 'videoId': videoId,
                 'title': title,
@@ -74,7 +76,8 @@ def parse_playlist_items(results, menu_entries: List[List] = None):
                 'likeStatus': like,
                 'thumbnails': thumbnails,
                 'isAvailable': isAvailable,
-                'isExplicit': isExplicit
+                'isExplicit': isExplicit,
+                'videoType': videoType
             }
             if duration:
                 song['duration'] = duration


### PR DESCRIPTION
Based on https://github.com/sigma67/ytmusicapi/pull/264 and https://github.com/sigma67/ytmusicapi/pull/265

This PR adds the `videoType` field on playlist items.