### PR TITLE
Unrecognized case sensitive headers during auth

### DIFF
--- a/ytmusicapi/auth/browser.py
+++ b/ytmusicapi/auth/browser.py
@@ -10,7 +10,7 @@ path = os.path.dirname(os.path.realpath(__file__)) + os.sep
 
 def is_browser(headers: CaseInsensitiveDict) -> bool:
     browser_structure = {"authorization", "cookie"}
-    return browser_structure.issubset(headers.keys())
+    return all(key in headers for key in browser_structure)
 
 
 def setup_browser(filepath=None, headers_raw=None):

--- a/ytmusicapi/auth/oauth.py
+++ b/ytmusicapi/auth/oauth.py
@@ -19,7 +19,7 @@ def is_oauth(headers: CaseInsensitiveDict) -> bool:
         "token_type",
         "refresh_token",
     }
-    return oauth_structure.issubset(headers.keys())
+    return all(key in headers for key in oauth_structure)
 
 
 class YTMusicOAuth:


### PR DESCRIPTION
Browser authentication doesn't work when I copy request headers from Chrome. 
The reason is request headers are Capitalized in Chrome. 

From [CaseInsensitiveDict](https://requests.readthedocs.io/projects/cn/zh_CN/latest/_modules/requests/structures.html) docs:
`All keys are expected to be strings. The structure remembers the
    case of the last key to be set, and ``iter(instance)``,
    ``keys()``, ``items()``, ``iterkeys()``, and ``iteritems()``
    will contain case-sensitive keys. However, querying and contains
    testing is case insensitive::`

With that in mind I replaced "headers.keys()" method with better check and now check for request headers should be case insensitive.