### PR TITLE
Add external OAuth case to browser check

### DIFF
--- a/ytmusicapi/auth/browser.py
+++ b/ytmusicapi/auth/browser.py
@@ -10,7 +10,10 @@ path = os.path.dirname(os.path.realpath(__file__)) + os.sep
 
 def is_browser(headers: CaseInsensitiveDict) -> bool:
     browser_structure = {"authorization", "cookie"}
-    return all(key in headers for key in browser_structure)
+    return all(key in headers for key in browser_structure) or (
+        "authorization" in headers and headers["authorization"].startswith("Bearer ")
+    )
+    
 
 
 def setup_browser(filepath=None, headers_raw=None):

--- a/ytmusicapi/auth/browser.py
+++ b/ytmusicapi/auth/browser.py
@@ -10,10 +10,7 @@ path = os.path.dirname(os.path.realpath(__file__)) + os.sep
 
 def is_browser(headers: CaseInsensitiveDict) -> bool:
     browser_structure = {"authorization", "cookie"}
-    return all(key in headers for key in browser_structure) or (
-        "authorization" in headers and headers["authorization"].startswith("Bearer ")
-    )
-    
+    return all(key in headers for key in browser_structure)    
 
 
 def setup_browser(filepath=None, headers_raw=None):

--- a/ytmusicapi/auth/browser.py
+++ b/ytmusicapi/auth/browser.py
@@ -10,7 +10,7 @@ path = os.path.dirname(os.path.realpath(__file__)) + os.sep
 
 def is_browser(headers: CaseInsensitiveDict) -> bool:
     browser_structure = {"authorization", "cookie"}
-    return all(key in headers for key in browser_structure)    
+    return all(key in headers for key in browser_structure)
 
 
 def setup_browser(filepath=None, headers_raw=None):

--- a/ytmusicapi/auth/headers.py
+++ b/ytmusicapi/auth/headers.py
@@ -6,7 +6,7 @@ import requests
 from requests.structures import CaseInsensitiveDict
 
 from ytmusicapi.auth.browser import is_browser
-from ytmusicapi.auth.oauth import YTMusicOAuth, is_oauth
+from ytmusicapi.auth.oauth import YTMusicOAuth, is_oauth, is_custom_oauth
 from ytmusicapi.helpers import initialize_headers
 
 
@@ -34,6 +34,9 @@ def prepare_headers(
             headers = oauth.load_headers(dict(input_dict), auth)
 
         elif is_browser(input_dict):
+            headers = input_dict
+
+        elif is_custom_oauth(input_dict):
             headers = input_dict
 
         else:

--- a/ytmusicapi/auth/oauth.py
+++ b/ytmusicapi/auth/oauth.py
@@ -22,6 +22,11 @@ def is_oauth(headers: CaseInsensitiveDict) -> bool:
     return all(key in headers for key in oauth_structure)
 
 
+def is_custom_oauth(headers: CaseInsensitiveDict) -> bool:
+    """Checks whether the headers contain a Bearer token, indicating a custom OAuth implementation."""
+    return "authorization" in headers and headers["authorization"].startswith("Bearer ")
+
+
 class YTMusicOAuth:
     """OAuth implementation for YouTube Music based on YouTube TV"""
 


### PR DESCRIPTION
Hi 👋 ,

I use this project as a dependency for a project where I retrieve an OAuth token myself and set it on the headers to authenticate. Since version 1.0.1 this started failing, because this method is not recognized as either browser_auth or oauth. 

This PR extends the browser check to make sure that the `Authorization` value is an OAuth token in case no `Cookie` is supplied.

Regards,
Marvin