### PR TITLE
Fix for error on `ytmusic.get_library_upload_songs(...)`

### DIFF
--- a/ytmusicapi/parsers/uploads.py
+++ b/ytmusicapi/parsers/uploads.py
@@ -8,7 +8,7 @@ def parse_uploaded_items(results):
         data = result[MRLIR]
         if 'menu' not in data:
             continue
-        entityId = nav(data, MENU_ITEMS)[-1]['menuNavigationItemRenderer']['navigationEndpoint'][
+        entityId = nav(data, MENU_ITEMS)[-2]['menuNavigationItemRenderer']['navigationEndpoint'][
             'confirmDialogEndpoint']['content']['confirmDialogRenderer']['confirmButton'][
                 'buttonRenderer']['command']['musicDeletePrivatelyOwnedEntityCommand']['entityId']
 


### PR DESCRIPTION
API results now return 2 items rather than one, so the current implementation breaks. This change fixes things.

Long term, may want to have a search based solution, but this fixes things for the time being.

Closes #406