### PR TITLE
Small edit only - removed redundant loop counter

### DIFF
--- a/ytmusicapi/parsers/playlists.py
+++ b/ytmusicapi/parsers/playlists.py
@@ -5,9 +5,7 @@ from ._utils import *
 
 def parse_playlist_items(results, menu_entries: List[List] = None):
     songs = []
-    count = 1
     for result in results:
-        count += 1
         if MRLIR not in result:
             continue
         data = result[MRLIR]


### PR DESCRIPTION
The count in parse_playlist_items is not referenced elsewhere in the function.