### PR TITLE
Move pop_songs_random_mix to be after results check.

### DIFF
--- a/ytmusicapi/mixins/uploads.py
+++ b/ytmusicapi/mixins/uploads.py
@@ -46,9 +46,9 @@ class UploadsMixin:
             body["params"] = prepare_order_params(order)
         response = self._send_request(endpoint, body)
         results = get_library_contents(response, MUSIC_SHELF)
-        pop_songs_random_mix(results)
         if results is None:
             return []
+        pop_songs_random_mix(results)
         songs = parse_uploaded_items(results['contents'])
 
         if 'continuations' in results:


### PR DESCRIPTION
Easy quick change. Just moving the pop_songs_random_mix() call to be after the check for empty results.