### PR TITLE
get_album: track_number returns none when track unavailable + test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,18 +24,6 @@ def fixture_sample_album() -> str:
     return "MPREb_4pL8gzRtw1p"
 
 
-@pytest.fixture(name="missing_indices_album")
-def fixture_missing_indices_album() -> str:
-    """Sean Paul - Dutty Classics Collection"""
-    return "MPREb_TPH4WqN5pUo"
-
-
-@pytest.fixture(name="disabled_indices_album")
-def fixture_disabled_indices_album() -> str:
-    """Kristian Conde - Absolutely Kristian Conde"""
-    return "MPREb_YuigcYm2erf"
-
-
 @pytest.fixture(name="sample_video")
 def fixture_sample_video() -> str:
     """Oasis - Wonderwall"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,10 +24,16 @@ def fixture_sample_album() -> str:
     return "MPREb_4pL8gzRtw1p"
 
 
-@pytest.fixture(name="badly_indexed_album")
-def fixture_badly_indexed_album() -> str:
+@pytest.fixture(name="missing_indices_album")
+def fixture_missing_indices_album() -> str:
     """Sean Paul - Dutty Classics Collection"""
     return "MPREb_TPH4WqN5pUo"
+
+
+@pytest.fixture(name="disabled_indices_album")
+def fixture_disabled_indices_album() -> str:
+    """Kristian Conde - Absolutely Kristian Conde"""
+    return "MPREb_YuigcYm2erf"
 
 
 @pytest.fixture(name="sample_video")

--- a/tests/mixins/test_browsing.py
+++ b/tests/mixins/test_browsing.py
@@ -66,7 +66,7 @@ class TestBrowsing:
         escaped_browse_id = yt.get_album_browse_id("OLAK5uy_nbMYyrfeg5ZgknoOsOGBL268hGxtcbnDM")
         assert escaped_browse_id == "MPREb_scJdtUCpPE2"
 
-    def test_get_album(self, yt, yt_auth, sample_album, missing_indices_album, disabled_indices_album):
+    def test_get_album(self, yt, yt_auth, sample_album):
         results = yt_auth.get_album(sample_album)
         assert len(results) >= 9
         assert results["tracks"][0]["isExplicit"]
@@ -80,10 +80,10 @@ class TestBrowsing:
         assert len(results["tracks"][0]["artists"]) == 1
         results = yt.get_album("MPREb_rqH94Zr3NN0")
         assert len(results["tracks"][0]["artists"]) == 2
-        results = yt.get_album(missing_indices_album)  # album with tracks completely removed
+        results = yt.get_album("MPREb_TPH4WqN5pUo")  # album with tracks completely removed/missing
         assert results["tracks"][0]["track_number"] == 3
         assert results["tracks"][13]["track_number"] == 18
-        results = yt.get_album(disabled_indices_album)  # album with track (#8) disabled/greyed out
+        results = yt.get_album("MPREb_YuigcYm2erf")  # album with track (#8) disabled/greyed out
         assert results["tracks"][7]["track_number"] is None
 
     def test_get_song(self, config, yt, yt_oauth, sample_video):

--- a/tests/mixins/test_browsing.py
+++ b/tests/mixins/test_browsing.py
@@ -66,7 +66,7 @@ class TestBrowsing:
         escaped_browse_id = yt.get_album_browse_id("OLAK5uy_nbMYyrfeg5ZgknoOsOGBL268hGxtcbnDM")
         assert escaped_browse_id == "MPREb_scJdtUCpPE2"
 
-    def test_get_album(self, yt, yt_auth, sample_album, badly_indexed_album):
+    def test_get_album(self, yt, yt_auth, sample_album, missing_indices_album, disabled_indices_album):
         results = yt_auth.get_album(sample_album)
         assert len(results) >= 9
         assert results["tracks"][0]["isExplicit"]
@@ -80,9 +80,11 @@ class TestBrowsing:
         assert len(results["tracks"][0]["artists"]) == 1
         results = yt.get_album("MPREb_rqH94Zr3NN0")
         assert len(results["tracks"][0]["artists"]) == 2
-        results = yt.get_album(badly_indexed_album)  # album with non-standard indexing
+        results = yt.get_album(missing_indices_album)  # album with tracks completely removed
         assert results["tracks"][0]["track_number"] == 3
         assert results["tracks"][13]["track_number"] == 18
+        results = yt.get_album(disabled_indices_album)  # album with track (#8) disabled/greyed out
+        assert results["tracks"][7]["track_number"] is None
 
     def test_get_song(self, config, yt, yt_oauth, sample_video):
         song = yt_oauth.get_song(config["uploads"]["private_upload_id"])  # private upload

--- a/ytmusicapi/parsers/playlists.py
+++ b/ytmusicapi/parsers/playlists.py
@@ -94,8 +94,11 @@ def parse_playlist_items(results, menu_entries: Optional[List[List]] = None, is_
         }
 
         if is_album:
-            track_idx_found = nav(data, ["index", "runs", 0, "text"], True)
-            song["track_number"] = track_idx_found if track_idx_found is None else int(track_idx_found)
+            if not isAvailable:
+                song["track_number"] = None
+            else:
+                # returning None from nav is pointless as the keys are always present
+                song["track_number"] = int(nav(data, ["index", "runs", 0, "text"]))
 
         if duration:
             song["duration"] = duration

--- a/ytmusicapi/parsers/playlists.py
+++ b/ytmusicapi/parsers/playlists.py
@@ -94,11 +94,7 @@ def parse_playlist_items(results, menu_entries: Optional[List[List]] = None, is_
         }
 
         if is_album:
-            if not isAvailable:
-                song["track_number"] = None
-            else:
-                # returning None from nav is pointless as the keys are always present
-                song["track_number"] = int(nav(data, ["index", "runs", 0, "text"]))
+            song["track_number"] = int(nav(data, ["index", "runs", 0, "text"])) if isAvailable else None
 
         if duration:
             song["duration"] = duration


### PR DESCRIPTION
Simple fix for #515 and adds test case for albums with unavailable tracks. 

Issue could alternatively be solved by extending nav's none_if_absent to coerce nullish return values. thoughts?