### PR TITLE
Remove offset + fix top result

### DIFF
--- a/ytmusicapi/parsers/search.py
+++ b/ytmusicapi/parsers/search.py
@@ -35,13 +35,8 @@ def parse_top_result(data, search_result_types):
 
     if result_type in ["song", "video", "album"]:
         on_tap = data.get("onTap")
-        if on_tap is not None:
-            if "watchEndpoint" in on_tap:
-                if nav(on_tap, WATCH_VIDEO_ID) is not None:
-                    search_result["videoId"] = nav(on_tap, WATCH_VIDEO_ID)
-            if "navigationEndpoint" in on_tap:
-                if nav(on_tap, NAVIGATION_VIDEO_TYPE) is not None:
-                    search_result["videoType"] = nav(on_tap, NAVIGATION_VIDEO_TYPE)
+        search_result["videoId"] = nav(data, ["onTap"] + WATCH_VIDEO_ID, True)
+        search_result["videoType"] = nav(data, ["onTap"] + NAVIGATION_VIDEO_TYPE, True)
 
         search_result["title"] = nav(data, TITLE_TEXT)
         runs = nav(data, ["subtitle", "runs"])

--- a/ytmusicapi/parsers/search.py
+++ b/ytmusicapi/parsers/search.py
@@ -34,7 +34,6 @@ def parse_top_result(data, search_result_types):
             search_result["videoType"] = nav(on_tap, NAVIGATION_VIDEO_TYPE)
 
     if result_type in ["song", "video", "album"]:
-        on_tap = data.get("onTap")
         search_result["videoId"] = nav(data, ["onTap"] + WATCH_VIDEO_ID, True)
         search_result["videoType"] = nav(data, ["onTap"] + NAVIGATION_VIDEO_TYPE, True)
 

--- a/ytmusicapi/parsers/search.py
+++ b/ytmusicapi/parsers/search.py
@@ -34,8 +34,13 @@ def parse_top_result(data, search_result_types):
             search_result["videoType"] = nav(on_tap, NAVIGATION_VIDEO_TYPE)
 
     if result_type in ["song", "video", "album"]:
+        on_tap = data.get("onTap")
+        if on_tap:
+            search_result["videoId"] = nav(on_tap, WATCH_VIDEO_ID)
+            search_result["videoType"] = nav(on_tap, NAVIGATION_VIDEO_TYPE)
+
         search_result["title"] = nav(data, TITLE_TEXT)
-        runs = nav(data, ["subtitle", "runs"])[2:]
+        runs = nav(data, ["subtitle", "runs"])
         song_info = parse_song_runs(runs)
         search_result.update(song_info)
 
@@ -125,7 +130,7 @@ def parse_search_result(data, search_result_types, result_type, category):
         search_result["duration"] = None
         search_result["year"] = None
         flex_item = get_flex_column_item(data, 1)
-        runs = flex_item["text"]["runs"][default_offset:]
+        runs = flex_item["text"]["runs"]
         song_info = parse_song_runs(runs)
         search_result.update(song_info)
 

--- a/ytmusicapi/parsers/search.py
+++ b/ytmusicapi/parsers/search.py
@@ -35,9 +35,13 @@ def parse_top_result(data, search_result_types):
 
     if result_type in ["song", "video", "album"]:
         on_tap = data.get("onTap")
-        if on_tap:
-            search_result["videoId"] = nav(on_tap, WATCH_VIDEO_ID)
-            search_result["videoType"] = nav(on_tap, NAVIGATION_VIDEO_TYPE)
+        if on_tap is not None:
+            if "watchEndpoint" in on_tap:
+                if nav(on_tap, WATCH_VIDEO_ID) is not None:
+                    search_result["videoId"] = nav(on_tap, WATCH_VIDEO_ID)
+            if "navigationEndpoint" in on_tap:
+                if nav(on_tap, NAVIGATION_VIDEO_TYPE) is not None:
+                    search_result["videoType"] = nav(on_tap, NAVIGATION_VIDEO_TYPE)
 
         search_result["title"] = nav(data, TITLE_TEXT)
         runs = nav(data, ["subtitle", "runs"])


### PR DESCRIPTION
Issue - https://github.com/sigma67/ytmusicapi/issues/518
These offsets cause an issue 

Fix, I test this way 
![image](https://github.com/sigma67/ytmusicapi/assets/10100397/dca578ff-37e6-4f9f-9194-e367ae0a1072)

Before
[BeforeChange.txt](https://github.com/sigma67/ytmusicapi/files/13929569/BeforeChange.txt)

After
[AfterChanges.txt](https://github.com/sigma67/ytmusicapi/files/13929572/AfterChanges.txt)

Differences
![image](https://github.com/sigma67/ytmusicapi/assets/10100397/ed78822e-e3aa-43c1-bee6-98b13c051778)


Only issue is this 

![image](https://github.com/sigma67/ytmusicapi/assets/10100397/70a566dd-0010-484a-a905-81583a7362c3)


But this is because code forced in to append `None` for artist without `Id` but then again, what if an artist name is "Album" can't just filter that out by keyword. I think this append of `None` should be taken out because with the way youtube music and youtube topic channels are auto-created I think it is safe to say most artists would have an id, no? 

Let me know and I can commit that change, thanks!