### PR TITLE
handle playlists appearing in top results (closes #524)

### DIFF
--- a/tests/mixins/test_search.py
+++ b/tests/mixins/test_search.py
@@ -56,6 +56,13 @@ class TestSearch:
         assert len(results) > 10
         assert all(item["resultType"] == "episode" for item in results)
 
+    def test_search_top_result(self, yt):
+        results = yt.search("fdsfsfsd")  # issue 524
+        assert results[0]["category"] == "Top result"
+        assert results[0]["resultType"] == "playlist"
+        assert results[0]["playlistId"] == "PLK3q5XTYSK60QH3gDypSu3n9OBz6H9HfV"
+        assert len(results[0]["author"]) > 0
+
     def test_search_uploads(self, config, yt, yt_oauth):
         with pytest.raises(Exception, match="No filter can be set when searching uploads"):
             yt.search(

--- a/ytmusicapi/parsers/search.py
+++ b/ytmusicapi/parsers/search.py
@@ -45,6 +45,13 @@ def parse_top_result(data, search_result_types):
     if result_type in ["album"]:
         search_result["browseId"] = nav(data, TITLE + NAVIGATION_BROWSE_ID, True)
 
+    if result_type in ["playlist"]:
+        search_result["browseId"] = nav(data, MENU_PLAYLIST_ID)
+        search_result["title"] = nav(data, TITLE_TEXT)
+        author = parse_song_artists_runs(nav(data, ["subtitle", "runs"])[2:])
+        if len(author) > 0:
+            search_result["author"] = author[0]['name']
+
     search_result["thumbnails"] = nav(data, THUMBNAILS, True)
     return search_result
 

--- a/ytmusicapi/parsers/search.py
+++ b/ytmusicapi/parsers/search.py
@@ -46,11 +46,9 @@ def parse_top_result(data, search_result_types):
         search_result["browseId"] = nav(data, TITLE + NAVIGATION_BROWSE_ID, True)
 
     if result_type in ["playlist"]:
-        search_result["browseId"] = nav(data, MENU_PLAYLIST_ID)
+        search_result["playlistId"] = nav(data, MENU_PLAYLIST_ID)
         search_result["title"] = nav(data, TITLE_TEXT)
-        author = parse_song_artists_runs(nav(data, ["subtitle", "runs"])[2:])
-        if len(author) > 0:
-            search_result["author"] = author[0]['name']
+        search_result["author"] = parse_song_artists_runs(nav(data, ["subtitle", "runs"])[2:])
 
     search_result["thumbnails"] = nav(data, THUMBNAILS, True)
     return search_result


### PR DESCRIPTION
parse playlists appearing in top results returning results the same way as for other playlists found be search()