### PR TITLE
Fix OAUTH_CUSTOM_FULL mode

### DIFF
--- a/ytmusicapi/ytmusic.py
+++ b/ytmusicapi/ytmusic.py
@@ -211,6 +211,11 @@ class YTMusicBase:
         if self.auth_type == AuthType.BROWSER:
             self._headers["authorization"] = get_authorization(self.sapisid + " " + self.origin)
 
+        # Override the headers with the auth / input_dict when using OAUTH_CUSTOM_FULL
+        # Full headers are provided by the downstream client in this scenario.
+        elif self.auth_type == AuthType.OAUTH_CUSTOM_FULL:
+            self._headers = self._input_dict
+
         elif self.auth_type in AuthType.oauth_types():
             self._headers["authorization"] = self._token.as_auth()
             self._headers["X-Goog-Request-Time"] = str(int(time.time()))

--- a/ytmusicapi/ytmusic.py
+++ b/ytmusicapi/ytmusic.py
@@ -211,12 +211,9 @@ class YTMusicBase:
         if self.auth_type == AuthType.BROWSER:
             self._headers["authorization"] = get_authorization(self.sapisid + " " + self.origin)
 
-        # Override the headers with the auth / input_dict when using OAUTH_CUSTOM_FULL
+        # Do not set custom headers when using OAUTH_CUSTOM_FULL
         # Full headers are provided by the downstream client in this scenario.
-        elif self.auth_type == AuthType.OAUTH_CUSTOM_FULL:
-            self._headers = self._input_dict
-
-        elif self.auth_type in AuthType.oauth_types():
+        elif self.auth_type in [x for x in AuthType.oauth_types() if x != AuthType.OAUTH_CUSTOM_FULL]:
             self._headers["authorization"] = self._token.as_auth()
             self._headers["X-Goog-Request-Time"] = str(int(time.time()))
 


### PR DESCRIPTION
This PR adds the missing `AuthType.OAUTH_CUSTOM_FULL` mode when calculating the headers. We (Music Assistant) use our own web-based OAuth process to retrieve an acces token. In this scenario we also provide the other required headers to interact with Youtube Music.