### PR TITLE
nav() now displays some debugging information on KeyError

### DIFF
--- a/ytmusicapi/navigation.py
+++ b/ytmusicapi/navigation.py
@@ -92,14 +92,14 @@ def nav(root: Dict, items: List[Any], none_if_absent: Literal[True] = True) -> O
 
 def nav(root: Dict, items: List[Any], none_if_absent: bool = False) -> Optional[Any]:
     """Access a nested object in root by item sequence."""
-    for k in items:
-        try:
+    try:
+        for k in items:
             root = root[k]
-        except (KeyError, IndexError) as e:
-            if none_if_absent:
-                return None
-            raise type(e)(f"Unable to find '{k}' using path {items!r} on {root!r}, exception: {e}")
-    return root
+        return root
+    except (KeyError, IndexError) as e:
+        if none_if_absent:
+            return None
+        raise type(e)(f"Unable to find '{k}' using path {items!r} on {root!r}, exception: {e}")
 
 
 def find_object_by_key(object_list, key, nested=None, is_key=False):

--- a/ytmusicapi/navigation.py
+++ b/ytmusicapi/navigation.py
@@ -92,13 +92,13 @@ def nav(root: Dict, items: List[Any], none_if_absent: Literal[True] = True) -> O
 
 def nav(root: Dict, items: List[Any], none_if_absent: bool = False) -> Optional[Any]:
     """Access a nested object in root by item sequence."""
-    for k in items:
-        try:
+    try:
+        for k in items:
             root = root[k]
-        except (KeyError, IndexError, TypeError) as e:
-            if none_if_absent:
-                return None
-            raise type(e)(f"Unable to find '{k}' using path {items!r} on {root!r}, exception: {e}")
+    except (KeyError, IndexError, TypeError) as e:
+        if none_if_absent:
+            return None
+        raise type(e)(f"Unable to find '{k}' using path {items!r} on {root!r}, exception: {e}")
     return root
 
 

--- a/ytmusicapi/navigation.py
+++ b/ytmusicapi/navigation.py
@@ -92,14 +92,14 @@ def nav(root: Dict, items: List[Any], none_if_absent: Literal[True] = True) -> O
 
 def nav(root: Dict, items: List[Any], none_if_absent: bool = False) -> Optional[Any]:
     """Access a nested object in root by item sequence."""
-    try:
-        for k in items:
+    for k in items:
+        try:
             root = root[k]
-        return root
-    except (KeyError, IndexError) as e:
-        if none_if_absent:
-            return None
-        raise type(e)(f"Unable to find '{k}' using path {items!r} on {root!r}, exception: {e}")
+        except (KeyError, IndexError, TypeError) as e:
+            if none_if_absent:
+                return None
+            raise type(e)(f"Unable to find '{k}' using path {items!r} on {root!r}, exception: {e}")
+    return root
 
 
 def find_object_by_key(object_list, key, nested=None, is_key=False):

--- a/ytmusicapi/navigation.py
+++ b/ytmusicapi/navigation.py
@@ -93,11 +93,12 @@ def nav(root: Dict, items: List[Any], none_if_absent: Literal[True] = True) -> O
 def nav(root: Dict, items: List[Any], none_if_absent: bool = False) -> Optional[Any]:
     """Access a nested object in root by item sequence."""
     for k in items:
-        if k not in root:
+        try:
+            root = root[k]
+        except (KeyError, IndexError) as e:
             if none_if_absent:
                 return None
-            raise KeyError(f"Unable to find '{k}' in {root!r}")
-        root = root[k]
+            raise type(e)(f"Unable to find '{k}' using path {items!r} on {root!r}, exception: {e}")
     return root
 
 

--- a/ytmusicapi/navigation.py
+++ b/ytmusicapi/navigation.py
@@ -92,15 +92,13 @@ def nav(root: Dict, items: List[Any], none_if_absent: Literal[True] = True) -> O
 
 def nav(root: Dict, items: List[Any], none_if_absent: bool = False) -> Optional[Any]:
     """Access a nested object in root by item sequence."""
-    try:
-        for k in items:
-            root = root[k]
-        return root
-    except Exception as err:
-        if none_if_absent:
-            return None
-        else:
-            raise err
+    for k in items:
+        if k not in root:
+            if none_if_absent:
+                return None
+            raise KeyError(f"Unable to find '{k}' in {root!r}")
+        root = root[k]
+    return root
 
 
 def find_object_by_key(object_list, key, nested=None, is_key=False):


### PR DESCRIPTION
There's a user reporting a KeyError in nav(), so I've changed it to print out the key and dict for future debugging.  Also, a bare Exception was used to capture a dictionary failure, removed that since my change checks for the existence of the key in the dictionary. If this is objectionable at all, you probably should change it to catching a KeyError rather than catching Exception.

This is to gather information for #539 