### PR TITLE
add package-data so pip installs working translations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ readme = {file = ["README.rst"]}
 [tool.setuptools_scm]
 
 [tool.setuptools]
-include-package-data=false
+include-package-data=true
 
 [tool.setuptools.package-data]
 "*" = ["**.rst", "**.py", "**.mo"]


### PR DESCRIPTION
When installing this package through pip localisation files are not found:

FileNotFoundError: [Errno 2] No translation file found for domain: 'base'

At:
  /usr/lib/python3.10/gettext.py(607): translation
  /usr/lib/python3/dist-packages/ytmusicapi/ytmusic.py(164): __init__


Enabling include-package-data fixes this problem