### PR TITLE
adding Optional type hinting for limits ( fix #565 )

### DIFF
--- a/ytmusicapi/mixins/library.py
+++ b/ytmusicapi/mixins/library.py
@@ -10,7 +10,7 @@ from ._utils import *
 
 
 class LibraryMixin(MixinProtocol):
-    def get_library_playlists(self, limit: int = 25) -> List[Dict]:
+    def get_library_playlists(self, limit: Optional[int] = 25) -> List[Dict]:
         """
         Retrieves the playlists in the user's library.
 

--- a/ytmusicapi/mixins/playlists.py
+++ b/ytmusicapi/mixins/playlists.py
@@ -12,7 +12,7 @@ from ._utils import *
 
 class PlaylistsMixin(MixinProtocol):
     def get_playlist(
-        self, playlistId: str, limit: int = 100, related: bool = False, suggestions_limit: int = 0
+        self, playlistId: str, limit: Optional[int] = 100, related: bool = False, suggestions_limit: int = 0
     ) -> Dict:
         """
         Returns a list of playlist items

--- a/ytmusicapi/mixins/uploads.py
+++ b/ytmusicapi/mixins/uploads.py
@@ -88,7 +88,9 @@ class UploadsMixin(MixinProtocol):
             response, lambda additionalParams: self._send_request(endpoint, body, additionalParams), limit
         )
 
-    def get_library_upload_artists(self, limit: Optional[int] = 25, order: Optional[str] = None) -> List[Dict]:
+    def get_library_upload_artists(
+        self, limit: Optional[int] = 25, order: Optional[str] = None
+    ) -> List[Dict]:
         """
         Gets the artists of uploaded songs in the user's library.
 

--- a/ytmusicapi/mixins/uploads.py
+++ b/ytmusicapi/mixins/uploads.py
@@ -22,7 +22,7 @@ from ._utils import prepare_order_params, validate_order_parameter
 
 
 class UploadsMixin(MixinProtocol):
-    def get_library_upload_songs(self, limit: int = 25, order: Optional[str] = None) -> List[Dict]:
+    def get_library_upload_songs(self, limit: Optional[int] = 25, order: Optional[str] = None) -> List[Dict]:
         """
         Returns a list of uploaded songs
 
@@ -69,7 +69,7 @@ class UploadsMixin(MixinProtocol):
 
         return songs
 
-    def get_library_upload_albums(self, limit: int = 25, order: Optional[str] = None) -> List[Dict]:
+    def get_library_upload_albums(self, limit: Optional[int] = 25, order: Optional[str] = None) -> List[Dict]:
         """
         Gets the albums of uploaded songs in the user's library.
 
@@ -88,7 +88,7 @@ class UploadsMixin(MixinProtocol):
             response, lambda additionalParams: self._send_request(endpoint, body, additionalParams), limit
         )
 
-    def get_library_upload_artists(self, limit: int = 25, order: Optional[str] = None) -> List[Dict]:
+    def get_library_upload_artists(self, limit: Optional[int] = 25, order: Optional[str] = None) -> List[Dict]:
         """
         Gets the artists of uploaded songs in the user's library.
 


### PR DESCRIPTION
Adding Optional typing for limit in methods whose documentation explicitly allows the use of None type for no limit. This fixes wrong error hinting in editors.

[ contribution requested in #565 ]