### PR TITLE
Prevent KeyError when using get_account_info() on a user that doesn't have a YouTube channel

### DIFF
--- a/ytmusicapi/mixins/library.py
+++ b/ytmusicapi/mixins/library.py
@@ -440,7 +440,7 @@ class LibraryMixin(MixinProtocol):
         ACCOUNT_PHOTO_URL = [*ACCOUNT_INFO, "accountPhoto", "thumbnails", 0, "url"]
 
         account_name = nav(response, ACCOUNT_NAME)
-        channel_handle = nav(response, ACCOUNT_CHANNEL_HANDLE)
+        channel_handle = nav(response, ACCOUNT_CHANNEL_HANDLE, none_if_absent=True)
         account_photo_url = nav(response, ACCOUNT_PHOTO_URL)
 
         return {


### PR DESCRIPTION
`get_account_info()` raises a KeyError if the user does not have a channel handle because they never created a YouTube channel. Seems like a perfect reason to use the handy `none_if_absent` flag :)