### PR TITLE
Gracefully retrieve uploaded songs with a blank duration (#578)

### DIFF
--- a/tests/mixins/test_playlists.py
+++ b/tests/mixins/test_playlists.py
@@ -107,6 +107,7 @@ class TestPlaylists:
         assert len(response["playlistEditResults"]) > 0, "Adding playlist item failed"
         time.sleep(3)
         yt_brand.edit_playlist(playlist_id, addToTop=False)
+        time.sleep(3)
         playlist = yt_brand.get_playlist(playlist_id, related=True)
         assert len(playlist["tracks"]) == 46, "Getting playlist items failed"
         response = yt_brand.remove_playlist_items(playlist_id, playlist["tracks"])

--- a/tests/mixins/test_uploads.py
+++ b/tests/mixins/test_uploads.py
@@ -1,6 +1,5 @@
 import tempfile
 import time
-from pathlib import Path
 
 import pytest
 

--- a/tests/mixins/test_uploads.py
+++ b/tests/mixins/test_uploads.py
@@ -63,9 +63,7 @@ class TestUploads:
             # Need to wait for song to be fully deleted
             time.sleep(10)
             # Now re-upload
-            upload_response = yt_auth.upload_song(
-                get_resource(config["uploads"]["file"])
-            )
+            upload_response = yt_auth.upload_song(get_resource(config["uploads"]["file"]))
 
         assert (
             upload_response == "STATUS_SUCCEEDED" or upload_response.status_code == 200

--- a/tests/mixins/test_uploads.py
+++ b/tests/mixins/test_uploads.py
@@ -1,5 +1,6 @@
 import tempfile
 import time
+from pathlib import Path
 
 import pytest
 
@@ -54,7 +55,7 @@ class TestUploads:
         upload_response = yt_auth.upload_song(get_resource(config["uploads"]["file"]))
         if not isinstance(upload_response, str) and upload_response.status_code == 409:
             # Song is already in uploads. Delete it and re-upload
-            songs = yt_auth.get_library_upload_songs()
+            songs = yt_auth.get_library_upload_songs(limit=None, order="recently_added")
             delete_response = None
             for song in songs:
                 if song.get("title") in config["uploads"]["file"]:
@@ -70,10 +71,10 @@ class TestUploads:
         ), f"Song failed to upload {upload_response}"
 
         # Wait for upload to finish processing and verify it can be retrieved
-        retries_remaining = 15
+        retries_remaining = 5
         while retries_remaining:
-            time.sleep(3)
-            songs = yt_auth.get_library_upload_songs()
+            time.sleep(5)
+            songs = yt_auth.get_library_upload_songs(limit=None, order="recently_added")
             for song in songs:
                 if song.get("title") in config["uploads"]["file"]:
                     # Uploaded song found

--- a/tests/mixins/test_uploads.py
+++ b/tests/mixins/test_uploads.py
@@ -1,4 +1,5 @@
 import tempfile
+import time
 
 import pytest
 
@@ -46,6 +47,26 @@ class TestUploads:
     def test_upload_song(self, config, yt_auth):
         response = yt_auth.upload_song(get_resource(config["uploads"]["file"]))
         assert response.status_code == 409
+
+    def test_upload_song_and_verify(self, config, yt_auth):
+        """Upload a song and verify it can be retrieved after it finishes processing."""
+        response = yt_auth.upload_song(get_resource(config["uploads"]["file"]))
+        if not isinstance(response, str) and response.status_code == 409:
+            raise AssertionError(f"{config['uploads']['file']!r} was already uploaded. Delete it and re-run.")
+
+        assert response == "STATUS_SUCCEEDED" or response.status_code == 200, "Song failed to upload."
+
+        # Wait for upload to finish processing and verify it can be retrieved
+        retries_remaining = 15
+        while retries_remaining:
+            time.sleep(3)
+            songs = yt_auth.get_library_upload_songs()
+            for song in songs:
+                if song.get("title") in config["uploads"]["file"]:
+                    return
+            retries_remaining -= 1
+
+        raise AssertionError("Uploaded song was not found in library")
 
     @pytest.mark.skip(reason="Do not delete uploads")
     def test_delete_upload_entity(self, yt_oauth):

--- a/tests/mixins/test_uploads.py
+++ b/tests/mixins/test_uploads.py
@@ -4,6 +4,7 @@ import time
 import pytest
 
 from tests.conftest import get_resource
+from ytmusicapi.ytmusic import YTMusic
 
 
 class TestUploads:
@@ -48,13 +49,27 @@ class TestUploads:
         response = yt_auth.upload_song(get_resource(config["uploads"]["file"]))
         assert response.status_code == 409
 
-    def test_upload_song_and_verify(self, config, yt_auth):
+    def test_upload_song_and_verify(self, config, yt_auth: YTMusic):
         """Upload a song and verify it can be retrieved after it finishes processing."""
-        response = yt_auth.upload_song(get_resource(config["uploads"]["file"]))
-        if not isinstance(response, str) and response.status_code == 409:
-            raise AssertionError(f"{config['uploads']['file']!r} was already uploaded. Delete it and re-run.")
+        upload_response = yt_auth.upload_song(get_resource(config["uploads"]["file"]))
+        if not isinstance(upload_response, str) and upload_response.status_code == 409:
+            # Song is already in uploads. Delete it and re-upload
+            songs = yt_auth.get_library_upload_songs()
+            delete_response = None
+            for song in songs:
+                if song.get("title") in config["uploads"]["file"]:
+                    delete_response = yt_auth.delete_upload_entity(song["entityId"])
+            assert delete_response == "STATUS_SUCCEEDED"
+            # Need to wait for song to be fully deleted
+            time.sleep(10)
+            # Now re-upload
+            upload_response = yt_auth.upload_song(
+                get_resource(config["uploads"]["file"])
+            )
 
-        assert response == "STATUS_SUCCEEDED" or response.status_code == 200, "Song failed to upload."
+        assert (
+            upload_response == "STATUS_SUCCEEDED" or upload_response.status_code == 200
+        ), f"Song failed to upload {upload_response}"
 
         # Wait for upload to finish processing and verify it can be retrieved
         retries_remaining = 15
@@ -63,6 +78,7 @@ class TestUploads:
             songs = yt_auth.get_library_upload_songs()
             for song in songs:
                 if song.get("title") in config["uploads"]["file"]:
+                    # Uploaded song found
                     return
             retries_remaining -= 1
 

--- a/ytmusicapi/parsers/_utils.py
+++ b/ytmusicapi/parsers/_utils.py
@@ -61,7 +61,8 @@ def get_dot_separator_index(runs):
 
 
 def parse_duration(duration):
-    if duration is None:
+    # duration may be falsy or a single space: ' '
+    if not duration or not duration.strip():
         return duration
     mapped_increments = zip([1, 60, 3600], reversed(duration.split(":")))
     seconds = sum(multiplier * int(time) for multiplier, time in mapped_increments)

--- a/ytmusicapi/parsers/uploads.py
+++ b/ytmusicapi/parsers/uploads.py
@@ -30,7 +30,9 @@ def parse_uploaded_items(results):
         title = get_item_text(data, 0)
         like = nav(data, MENU_LIKE_STATUS)
         thumbnails = nav(data, THUMBNAILS) if "thumbnail" in data else None
-        duration = get_fixed_column_item(data, 0)["text"]["runs"][0]["text"]
+        duration = None
+        if "fixedColumns" in data:
+            duration = get_fixed_column_item(data, 0)["text"]["runs"][0]["text"]
         song = {
             "entityId": entityId,
             "videoId": videoId,


### PR DESCRIPTION
Fixes #578 

This prevents a possible KeyError or a int-parsing error when an uploaded song has a duration that is not a valid value like "3:31".

Per-recent changes by Google, an uploaded song can have a duration of `' '` or simply not have a `fixedColumns` object at all. This is most commonly seen immediately after uploading a song but can be seen in other cases as well.

I added a unit test that exercises this. It uploads a song and then starts calling `get_library_upload_songs()` in a loop, waiting for the song to be available. Without my duration fix, this encounters a parsing error. With the fix, it succeeds.