### PR TITLE
parse_seach_result: add playlist id to album search

### DIFF
--- a/ytmusicapi/mixins/search.py
+++ b/ytmusicapi/mixins/search.py
@@ -83,8 +83,9 @@ class SearchMixin(MixinProtocol):
               {
                 "category": "Albums",
                 "resultType": "album",
-                "browseId": "MPREb_9nqEki4ZDpp",
-                "title": "(What's The Story) Morning Glory? (Remastered)",
+                "browseId": "MPREb_IInSY5QXXrW",
+                "playlistId": "OLAK5uy_kunInnOpcKECWIBQGB0Qj6ZjquxDvfckg",
+                "title": "(What's The Story) Morning Glory?",
                 "type": "Album",
                 "artist": "Oasis",
                 "year": "1995",

--- a/ytmusicapi/parsers/search.py
+++ b/ytmusicapi/parsers/search.py
@@ -159,6 +159,13 @@ def parse_search_result(data, search_result_types, result_type, category):
     if result_type in ["song", "album"]:
         search_result["isExplicit"] = nav(data, BADGE_LABEL, True) is not None
 
+    if result_type in ["album"]:
+        search_result["playlistId"] = nav(
+            data,
+            [*PLAY_BUTTON, "playNavigationEndpoint", "watchEndpoint", "playlistId"],
+            True,
+        )
+
     if result_type in ["episode"]:
         flex_item = get_flex_column_item(data, 1)
         has_date = int(len(nav(flex_item, TEXT_RUNS)) > 1)

--- a/ytmusicapi/parsers/search.py
+++ b/ytmusicapi/parsers/search.py
@@ -46,6 +46,7 @@ def parse_top_result(data, search_result_types):
 
     if result_type in ["album"]:
         search_result["browseId"] = nav(data, TITLE + NAVIGATION_BROWSE_ID, True)
+        search_result["playlistId"] = nav(data, ["buttons", 0, "buttonRenderer", "command", *WATCH_PID], True)
 
     if result_type in ["playlist"]:
         search_result["playlistId"] = nav(data, MENU_PLAYLIST_ID)


### PR DESCRIPTION
Contributes to sigma67/ytmusicapi#585

`playlistId` is available in the search response and can be used to add an album to the library via `like/like` endpoint. So, including the `playlistId` when the query is filtered by `albums`  could be helpful.