### PR TITLE
playlist search result "itemCount" field cast to int

### DIFF
--- a/ytmusicapi/parsers/search.py
+++ b/ytmusicapi/parsers/search.py
@@ -96,7 +96,9 @@ def parse_search_result(data, search_result_types, result_type, category):
     elif result_type == "playlist":
         flex_item = get_flex_column_item(data, 1)["text"]["runs"]
         has_author = len(flex_item) == default_offset + 3
-        search_result["itemCount"] = get_item_text(data, 1, default_offset + has_author * 2).split(" ")[0]
+        search_result["itemCount"] = int(
+            get_item_text(data, 1, default_offset + has_author * 2).split(" ")[0]
+        )
         search_result["author"] = None if not has_author else get_item_text(data, 1, default_offset)
 
     elif result_type == "station":

--- a/ytmusicapi/parsers/search.py
+++ b/ytmusicapi/parsers/search.py
@@ -1,3 +1,4 @@
+from ..helpers import to_int
 from ._utils import *
 from .songs import *
 
@@ -96,7 +97,7 @@ def parse_search_result(data, search_result_types, result_type, category):
     elif result_type == "playlist":
         flex_item = get_flex_column_item(data, 1)["text"]["runs"]
         has_author = len(flex_item) == default_offset + 3
-        search_result["itemCount"] = int(
+        search_result["itemCount"] = to_int(
             get_item_text(data, 1, default_offset + has_author * 2).split(" ")[0]
         )
         search_result["author"] = None if not has_author else get_item_text(data, 1, default_offset)


### PR DESCRIPTION
A search result of ```"resultType": "playlist"``` from YTMusic.search() contains a field ```"itemCount"```, which was always serialized as a json string, despite representing a number.

This pull request casts the python str to int, so ```"itemCount"``` is serialized as a json number.