### PR TITLE
edit_playlist(): Allow moving title to bottom of playlist

### DIFF
--- a/.github/workflows/coverage-pr.yml
+++ b/.github/workflows/coverage-pr.yml
@@ -1,12 +1,6 @@
 name: Code coverage
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - ytmusicapi/**
-      - tests/**
   pull_request_target:
     paths:
       - ytmusicapi/**
@@ -17,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Setup Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - ytmusicapi/**
       - tests/**
+  pull_request_target:
+    types: [labeled]
   pull_request:
     branches:
       - main

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,13 +9,7 @@ on:
       - tests/**
   pull_request_target:
     types:
-    - labeled
-    paths:
-      - ytmusicapi/**
-      - tests/**
-  pull_request:
-    branches:
-      - main
+      - labeled
     paths:
       - ytmusicapi/**
       - tests/**

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,11 @@ on:
       - ytmusicapi/**
       - tests/**
   pull_request_target:
-    types: [labeled]
+    types:
+    - labeled
+    paths:
+      - ytmusicapi/**
+      - tests/**
   pull_request:
     branches:
       - main

--- a/tests/mixins/test_playlists.py
+++ b/tests/mixins/test_playlists.py
@@ -66,7 +66,7 @@ class TestPlaylists:
 
     def test_edit_playlist(self, config, yt_brand):
         playlist = yt_brand.get_playlist(config["playlists"]["own"])
-        response = yt_brand.edit_playlist(
+        response1 = yt_brand.edit_playlist(
             playlist["id"],
             title="",
             description="",
@@ -76,8 +76,8 @@ class TestPlaylists:
                 playlist["tracks"][0]["setVideoId"],
             ),
         )
-        assert response == "STATUS_SUCCEEDED", "Playlist edit failed"
-        yt_brand.edit_playlist(
+        assert response1 == "STATUS_SUCCEEDED", "Playlist edit 1 failed"
+        response2 = yt_brand.edit_playlist(
             playlist["id"],
             title=playlist["title"],
             description=playlist["description"],
@@ -87,7 +87,15 @@ class TestPlaylists:
                 playlist["tracks"][1]["setVideoId"],
             ),
         )
-        assert response == "STATUS_SUCCEEDED", "Playlist edit failed"
+        assert response2 == "STATUS_SUCCEEDED", "Playlist edit 2 failed"
+        response3 = yt_brand.edit_playlist(
+            playlist["id"],
+            title=playlist["title"],
+            description=playlist["description"],
+            privacyStatus=playlist["privacy"],
+            moveItem=playlist["tracks"][0]["setVideoId"],
+        )
+        assert response3 == "STATUS_SUCCEEDED", "Playlist edit 3 failed"
 
     def test_end2end(self, yt_brand, sample_video):
         playlist_id = yt_brand.create_playlist(

--- a/ytmusicapi/mixins/playlists.py
+++ b/ytmusicapi/mixins/playlists.py
@@ -327,7 +327,7 @@ class PlaylistsMixin(MixinProtocol):
         title: Optional[str] = None,
         description: Optional[str] = None,
         privacyStatus: Optional[str] = None,
-        moveItem: Optional[Tuple[str, str]] = None,
+        moveItem: Optional[Union[str, Tuple[str, str]]] = None,
         addPlaylistId: Optional[str] = None,
         addToTop: Optional[bool] = None,
     ) -> Union[str, Dict]:
@@ -358,13 +358,13 @@ class PlaylistsMixin(MixinProtocol):
             actions.append({"action": "ACTION_SET_PLAYLIST_PRIVACY", "playlistPrivacy": privacyStatus})
 
         if moveItem:
-            actions.append(
-                {
-                    "action": "ACTION_MOVE_VIDEO_BEFORE",
-                    "setVideoId": moveItem[0],
-                    "movedSetVideoIdSuccessor": moveItem[1],
-                }
-            )
+            action = {
+                "action": "ACTION_MOVE_VIDEO_BEFORE",
+                "setVideoId": moveItem if isinstance(moveItem, str) else moveItem[0],
+            }
+            if isinstance(moveItem, tuple) and len(moveItem) > 1:
+                action["movedSetVideoIdSuccessor"] = moveItem[1]
+            actions.append(action)
 
         if addPlaylistId:
             actions.append({"action": "ACTION_ADD_PLAYLIST", "addedFullListId": addPlaylistId})


### PR DESCRIPTION
Patch to allow `edit_playlist()` to move a title to the end of a playlist. See #601.

