### PR TITLE
Extract song count from text

### DIFF
--- a/ytmusicapi/mixins/playlists.py
+++ b/ytmusicapi/mixins/playlists.py
@@ -211,8 +211,10 @@ class PlaylistsMixin(MixinProtocol):
             playlist["duration"] = (
                 None if not has_duration else second_subtitle_runs[has_views + has_duration]["text"]
             )
-            song_count = second_subtitle_runs[has_views + 0]["text"].split(" ")
-            song_count = to_int(song_count[0]) if len(song_count) > 1 else 0
+            song_count_text = second_subtitle_runs[has_views + 0]["text"]
+            song_count_search = re.search(r"\d+", song_count_text)
+            # extract the digits from the text, return 0 if no match
+            song_count = to_int(song_count_search.group()) if song_count_search is not None else 0
         else:
             song_count = len(section_list["contents"])
 

--- a/ytmusicapi/parsers/playlists.py
+++ b/ytmusicapi/parsers/playlists.py
@@ -38,8 +38,10 @@ def parse_playlist_header(response: Dict) -> Dict[str, Any]:
         playlist["duration"] = (
             None if not has_duration else second_subtitle_runs[has_views + has_duration]["text"]
         )
-        song_count = second_subtitle_runs[has_views + 0]["text"].split(" ")
-        song_count = to_int(song_count[0]) if len(song_count) > 1 else 0
+        song_count_text = second_subtitle_runs[has_views + 0]["text"]
+        song_count_search = re.search(r"\d+", song_count_text)
+        # extract the digits from the text, return 0 if no match
+        song_count = to_int(song_count_search.group()) if song_count_search is not None else 0
         playlist["trackCount"] = song_count
 
     return playlist


### PR DESCRIPTION
Use RegEx search to search for track count integer instead of using indexing. If the number cannot be extracted, return 0 as a fallback.

Addresses https://github.com/sigma67/ytmusicapi/issues/606