### PR TITLE
Extract song count from text

### DIFF
--- a/tests/mixins/test_playlists.py
+++ b/tests/mixins/test_playlists.py
@@ -5,6 +5,9 @@ from unittest import mock
 
 import pytest
 
+from ytmusicapi import YTMusic
+from ytmusicapi.constants import SUPPORTED_LANGUAGES
+
 
 class TestPlaylists:
     @pytest.mark.parametrize(
@@ -56,6 +59,12 @@ class TestPlaylists:
         playlist = yt_empty.get_playlist("PLj4BSJLnVpNyIjbCWXWNAmybc97FXLlTk", limit=None, related=True)
         assert len(playlist["tracks"]) > 200
         assert len(playlist["related"]) == 0
+
+    @pytest.mark.parametrize("language", SUPPORTED_LANGUAGES)
+    def test_get_playlist_languages(self, language):
+        yt = YTMusic(language=language)
+        result = yt.get_playlist("PLj4BSJLnVpNyIjbCWXWNAmybc97FXLlTk")
+        assert result["trackCount"] == 255
 
     def test_get_playlist_owned(self, config, yt_brand):
         playlist = yt_brand.get_playlist(config["playlists"]["own"], related=True, suggestions_limit=21)

--- a/ytmusicapi/mixins/playlists.py
+++ b/ytmusicapi/mixins/playlists.py
@@ -211,8 +211,10 @@ class PlaylistsMixin(MixinProtocol):
             playlist["duration"] = (
                 None if not has_duration else second_subtitle_runs[has_views + has_duration]["text"]
             )
-            song_count = second_subtitle_runs[has_views + 0]["text"].split(" ")
-            song_count = to_int(song_count[0]) if len(song_count) > 1 else 0
+            song_count_text = second_subtitle_runs[has_views + 0]["text"]
+            song_count_search = re.search(r"\d+", song_count_text)
+            # extract the digits from the text, return 0 if no match
+            song_count = to_int(song_count_search.group()) if song_count_search is not None else 0
         else:
             song_count = len(section_list["contents"])
 

--- a/ytmusicapi/parsers/playlists.py
+++ b/ytmusicapi/parsers/playlists.py
@@ -38,8 +38,10 @@ def parse_playlist_header(response: Dict) -> Dict[str, Any]:
         playlist["duration"] = (
             None if not has_duration else second_subtitle_runs[has_views + has_duration]["text"]
         )
-        song_count = second_subtitle_runs[has_views + 0]["text"].split(" ")
-        song_count = to_int(song_count[0]) if len(song_count) > 1 else 0
+        song_count_text = second_subtitle_runs[has_views + 0]["text"]
+        song_count_search = re.search(r"\d+", song_count_text)
+        # extract the digits from the text, return 0 if no match
+        song_count = to_int(song_count_search.group()) if song_count_search is not None else 0
         playlist["trackCount"] = song_count
 
     return playlist


### PR DESCRIPTION
Use RegEx search to search for track count integer instead of using indexing. If the number cannot be extracted, return 0 as a fallback. I never hit the error in parsers, but seeing as the logic is the same, I went ahead and changed it there too.

Addresses https://github.com/sigma67/ytmusicapi/issues/608