### PR TITLE
Return blank album author ID when it doesn't exist.

### DIFF
--- a/ytmusicapi/parsers/podcasts.py
+++ b/ytmusicapi/parsers/podcasts.py
@@ -61,10 +61,14 @@ class Description(List[DescriptionElement]):
 def parse_base_header(header: Dict) -> Dict:
     """parse common left hand side (header) items of an episode or podcast page"""
     strapline = nav(header, ["straplineTextOne"])
+    try:
+        author_id = nav(strapline, ["runs", 0, *NAVIGATION_BROWSE_ID])
+    except KeyError:
+        author_id = ""
     return {
         "author": {
             "name": nav(strapline, [*RUN_TEXT]),
-            "id": nav(strapline, ["runs", 0, *NAVIGATION_BROWSE_ID]),
+            "id": author_id,
         },
         "title": nav(header, TITLE_TEXT),
     }

--- a/ytmusicapi/parsers/podcasts.py
+++ b/ytmusicapi/parsers/podcasts.py
@@ -61,14 +61,10 @@ class Description(List[DescriptionElement]):
 def parse_base_header(header: Dict) -> Dict:
     """parse common left hand side (header) items of an episode or podcast page"""
     strapline = nav(header, ["straplineTextOne"])
-    try:
-        author_id = nav(strapline, ["runs", 0, *NAVIGATION_BROWSE_ID])
-    except KeyError:
-        author_id = ""
     return {
         "author": {
             "name": nav(strapline, [*RUN_TEXT]),
-            "id": author_id,
+            "id": nav(strapline, ["runs", 0, *NAVIGATION_BROWSE_ID]),
         },
         "title": nav(header, TITLE_TEXT),
     }

--- a/ytmusicapi/parsers/podcasts.py
+++ b/ytmusicapi/parsers/podcasts.py
@@ -64,7 +64,7 @@ def parse_base_header(header: Dict) -> Dict:
     return {
         "author": {
             "name": nav(strapline, [*RUN_TEXT]),
-            "id": nav(strapline, ["runs", 0, *NAVIGATION_BROWSE_ID]),
+            "id": nav(strapline, ["runs", 0, *NAVIGATION_BROWSE_ID], True),
         },
         "title": nav(header, TITLE_TEXT),
     }


### PR DESCRIPTION
This is a proposed fix for issue https://github.com/sigma67/ytmusicapi/issues/613, where if an album artist is "Various Artists" then there is no associated artist ID.

closes #613