### PR TITLE
get_album: fix invalid track list artists (#617)

### DIFF
--- a/ytmusicapi/parsers/playlists.py
+++ b/ytmusicapi/parsers/playlists.py
@@ -112,8 +112,7 @@ def parse_playlist_item(
         navigation_endpoint = nav(flex_column_item, [*TEXT_RUN, "navigationEndpoint"], True)
 
         if not navigation_endpoint:
-            if nav(flex_column_item, TEXT_RUN_TEXT, True) is not None:
-                unrecognized_index = index if unrecognized_index is None else unrecognized_index
+            unrecognized_index = index if unrecognized_index is None else unrecognized_index
             continue
 
         if "watchEndpoint" in navigation_endpoint:


### PR DESCRIPTION
Fixed invalid artists info for get_album from https://github.com/sigma67/ytmusicapi/issues/617 issue.

Bug was a result of my changes in #612.

This is a flexColumn for an artist:
 ```javascript
 {
 "musicResponsiveListItemFlexColumnRenderer": {
   "text": {},
  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
  }
}
```
 it was skipped in parsing, because it did not have `navigationEndpoint` and `text` was empty. "Plays" column has been used as an artist instead. I removed empty `text` check. Now it will be used as unrecognized artist column. Then `parse_song_artists` method will return `None` and in the end in  `get_album` method if artist track is `None`, then primary album artist will be used. So it will work exactly as in 1.7.3 and before.

Closes #617.