### PR TITLE
get_playlist: fix title for podcast episodes (#622)

### DIFF
--- a/ytmusicapi/parsers/playlists.py
+++ b/ytmusicapi/parsers/playlists.py
@@ -137,6 +137,9 @@ def parse_playlist_item(
                 album_index = index
             elif page_type == "MUSIC_PAGE_TYPE_USER_CHANNEL":
                 user_channel_indexes.append(index)
+            # Non music videos, for example: podcast episodes
+            elif page_type == "MUSIC_PAGE_TYPE_NON_MUSIC_AUDIO_TRACK_PAGE":
+                title_index = index
 
     # Extra check for rare songs, where artist is non-clickable and does not have navigationEndpoint
     if artist_index is None and unrecognized_index is not None:


### PR DESCRIPTION
Quick fix for get_playlist method. Some playlist items had None as a title. (#622)

After refactor in (#612),  title is resolved using `watchEndpoint`. Podcast episodes do not have one. They have `browseEndpoint` with `pageType = MUSIC_PAGE_TYPE_NON_MUSIC_AUDIO_TRACK_PAGE` instead. 


