### PR TITLE
fix #656: attempt to find runs in subtitle if not in title

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,12 +34,6 @@ def fixture_sample_video() -> str:
     return "hpSrLjc5SMs"
 
 
-@pytest.fixture(name="sample_playlist")
-def fixture_sample_playlist() -> str:
-    """very large playlist"""
-    return "PL6bPxvf5dW5clc3y9wAoslzqUrmkZ5c-u"
-
-
 @pytest.fixture(name="browser_filepath")
 def fixture_browser_filepath(config) -> str:
     return get_resource(config["auth"]["browser_file"])

--- a/ytmusicapi/mixins/playlists.py
+++ b/ytmusicapi/mixins/playlists.py
@@ -135,7 +135,10 @@ class PlaylistsMixin(MixinProtocol):
             else None
         )
         playlist["thumbnails"] = nav(header, THUMBNAILS)
-        playlist["title"] = nav(header, TITLE_TEXT)
+        playlist["title"] = nav(header, TITLE_TEXT, none_if_absent=True) or nav(
+            header, SUBTITLE, none_if_absent=False
+        )
+
         playlist.update(parse_song_runs(nav(header, SUBTITLE_RUNS)[2 + playlist["owned"] * 2 :]))
 
         playlist["views"] = None

--- a/ytmusicapi/mixins/playlists.py
+++ b/ytmusicapi/mixins/playlists.py
@@ -134,31 +134,10 @@ class PlaylistsMixin(MixinProtocol):
             if description_shelf
             else None
         )
-        playlist["thumbnails"] = nav(header, THUMBNAILS)
-        playlist["title"] = nav(header, TITLE_TEXT, none_if_absent=True) or nav(
-            header, SUBTITLE, none_if_absent=False
-        )
+
+        playlist.update(parse_playlist_header_meta(header))
 
         playlist.update(parse_song_runs(nav(header, SUBTITLE_RUNS)[2 + playlist["owned"] * 2 :]))
-
-        playlist["views"] = None
-        playlist["duration"] = None
-        if "runs" in header["secondSubtitle"]:
-            second_subtitle_runs = header["secondSubtitle"]["runs"]
-            has_views = (len(second_subtitle_runs) > 3) * 2
-            playlist["views"] = None if not has_views else to_int(second_subtitle_runs[0]["text"])
-            has_duration = (len(second_subtitle_runs) > 1) * 2
-            playlist["duration"] = (
-                None if not has_duration else second_subtitle_runs[has_views + has_duration]["text"]
-            )
-            song_count_text = second_subtitle_runs[has_views + 0]["text"]
-            song_count_search = re.findall(r"\d+", song_count_text)
-            # extract the digits from the text, return 0 if no match
-            song_count = to_int("".join(song_count_search)) if song_count_search is not None else None
-        else:
-            song_count = None
-
-        playlist["trackCount"] = song_count
 
         request_func = lambda additionalParams: self._send_request(endpoint, body, additionalParams)
 

--- a/ytmusicapi/parsers/playlists.py
+++ b/ytmusicapi/parsers/playlists.py
@@ -40,7 +40,7 @@ def parse_playlist_header_meta(header: dict[str, Any]) -> dict[str, Any]:
         "views": None,
         "duration": None,
         "trackCount": None,
-        "title": nav(header, TITLE_TEXT, none_if_absent=True) or nav(header, SUBTITLE, none_if_absent=False),
+        "title": nav(header, TITLE_TEXT, none_if_absent=True),
         "thumbnails": nav(header, THUMBNAILS),
     }
     if "runs" in header["secondSubtitle"]:

--- a/ytmusicapi/parsers/playlists.py
+++ b/ytmusicapi/parsers/playlists.py
@@ -19,12 +19,9 @@ def parse_playlist_header(response: dict) -> dict[str, Any]:
                 response, [*TWO_COLUMN_RENDERER, *TAB_CONTENT, *SECTION_LIST_ITEM, *RESPONSIVE_HEADER]
             )
 
-    playlist["title"] = nav(header, TITLE_TEXT, none_if_absent=True) or nav(
-        header, SUBTITLE, none_if_absent=False
-    )
-    playlist["thumbnails"] = nav(header, THUMBNAIL_CROPPED, True)
+    playlist.update(parse_playlist_header_meta(header))
     if playlist["thumbnails"] is None:
-        playlist["thumbnails"] = nav(header, THUMBNAILS)
+        playlist["thumbnails"] = nav(header, THUMBNAIL_CROPPED, True)
     playlist["description"] = nav(header, DESCRIPTION, True)
     run_count = len(nav(header, SUBTITLE_RUNS))
     if run_count > 1:
@@ -35,24 +32,33 @@ def parse_playlist_header(response: dict) -> dict[str, Any]:
         if run_count == 5:
             playlist["year"] = nav(header, SUBTITLE3)
 
-    playlist["views"] = None
-    playlist["duration"] = None
-    playlist["trackCount"] = None
+    return playlist
+
+
+def parse_playlist_header_meta(header: dict[str, Any]) -> dict[str, Any]:
+    playlist_meta = {
+        "views": None,
+        "duration": None,
+        "trackCount": None,
+        "title": nav(header, TITLE_TEXT, none_if_absent=True) or nav(header, SUBTITLE, none_if_absent=False),
+        "thumbnails": nav(header, THUMBNAILS),
+    }
     if "runs" in header["secondSubtitle"]:
         second_subtitle_runs = header["secondSubtitle"]["runs"]
         has_views = (len(second_subtitle_runs) > 3) * 2
-        playlist["views"] = None if not has_views else to_int(second_subtitle_runs[0]["text"])
+        playlist_meta["views"] = None if not has_views else to_int(second_subtitle_runs[0]["text"])
         has_duration = (len(second_subtitle_runs) > 1) * 2
-        playlist["duration"] = (
+        playlist_meta["duration"] = (
             None if not has_duration else second_subtitle_runs[has_views + has_duration]["text"]
         )
         song_count_text = second_subtitle_runs[has_views + 0]["text"]
-        song_count_search = re.search(r"\d+", song_count_text)
+        song_count_search = re.findall(r"\d+", song_count_text)
         # extract the digits from the text, return 0 if no match
-        song_count = to_int(song_count_search.group()) if song_count_search is not None else 0
-        playlist["trackCount"] = song_count
+        playlist_meta["trackCount"] = (
+            to_int("".join(song_count_search)) if song_count_search is not None else None
+        )
 
-    return playlist
+    return playlist_meta
 
 
 def parse_playlist_items(results, menu_entries: Optional[list[list]] = None, is_album=False):

--- a/ytmusicapi/parsers/playlists.py
+++ b/ytmusicapi/parsers/playlists.py
@@ -19,7 +19,9 @@ def parse_playlist_header(response: dict) -> dict[str, Any]:
                 response, [*TWO_COLUMN_RENDERER, *TAB_CONTENT, *SECTION_LIST_ITEM, *RESPONSIVE_HEADER]
             )
 
-    playlist["title"] = nav(header, TITLE_TEXT)
+    playlist["title"] = nav(header, TITLE_TEXT, none_if_absent=True) or nav(
+        header, SUBTITLE, none_if_absent=False
+    )
     playlist["thumbnails"] = nav(header, THUMBNAIL_CROPPED, True)
     if playlist["thumbnails"] is None:
         playlist["thumbnails"] = nav(header, THUMBNAILS)


### PR DESCRIPTION
Sometimes the object 'runs' is not to be found within title, but within
subtitle. This PR makes ytmusicapi look in both places.

Closes #656 


