### PR TITLE
fix #751: `parse_video` returns always a video ID or `None`

### DIFF
--- a/ytmusicapi/parsers/browsing.py
+++ b/ytmusicapi/parsers/browsing.py
@@ -117,7 +117,9 @@ def parse_video(result):
     videoId = nav(result, NAVIGATION_VIDEO_ID, True)
     if not videoId:
         videoId = next(
-            id for entry in nav(result, MENU_ITEMS) if nav(entry, MENU_SERVICE + QUEUE_VIDEO_ID, True)
+            video_id
+            for entry in nav(result, MENU_ITEMS)
+            if (video_id := nav(entry, MENU_SERVICE + QUEUE_VIDEO_ID, True))
         )
     return {
         "title": nav(result, TITLE_TEXT),


### PR DESCRIPTION
fix for #751 