### PR TITLE
 Fix get_artist to Retrieve Singles & EPs

### DIFF
--- a/ytmusicapi/parsers/i18n.py
+++ b/ytmusicapi/parsers/i18n.py
@@ -53,7 +53,7 @@ class Parser:
         # type: ignore[name-defined]
         categories = [
             ("albums", _("albums"), parse_album, MTRIR),
-            ("singles", _("singles"), parse_single, MTRIR),
+            ("singles", _("singles & EPs"), parse_single, MTRIR),
             ("shows", _("shows"), parse_album, MTRIR),
             ("videos", _("videos"), parse_video, MTRIR),
             ("playlists", _("playlists"), parse_playlist, MTRIR),


### PR DESCRIPTION
Hi, can you please review this change?

## Description:
YouTube Music changed the label from "Singles" to "Singles & EPs", causing ytmusicapi to no longer return singles in get_artist. See the screenshot below.

This PR updates parse_channel_contents to check for "Singles & EPs" instead of "singles", restoring the expected behavior.

## Changes:

Updated the categories list in parse_channel_contents to use _("singles & EPs") instead of _("singles").

## Testing:

Verified that get_artist now correctly returns singles.

## Screenshot

![image](https://github.com/user-attachments/assets/175cc059-d488-4100-ae46-ae60eb4eb9cd)
