### PR TITLE
Space between verification_url and comma in the OAuth Flow

### DIFF
--- a/ytmusicapi/auth/oauth/token.py
+++ b/ytmusicapi/auth/oauth/token.py
@@ -126,7 +126,7 @@ class RefreshingToken(OAuthToken):
         url = f"{code['verification_url']}?user_code={code['user_code']}"
         if open_browser:
             webbrowser.open(url)
-        input(f"Go to {url}, finish the login flow and press Enter when done, Ctrl-C to abort")
+        input(f"Go to {url} , finish the login flow and press Enter when done, Ctrl-C to abort")
         raw_token = credentials.token_from_code(code["device_code"])
         ref_token = cls(credentials=credentials, **raw_token)
         ref_token.update(ref_token.as_dict())


### PR DESCRIPTION
This fixes the situation in which the user ctrl + left clicks on the link in their terminal, and the comma is included as part of the code (which causes it not to work).