### PR TITLE
Don't throw an error if playlist title is missing (fixes #805)

### DIFF
--- a/ytmusicapi/parsers/browsing.py
+++ b/ytmusicapi/parsers/browsing.py
@@ -141,7 +141,11 @@ def parse_video(result: JsonDict) -> JsonDict:
 
 def parse_playlist(data: JsonDict) -> JsonDict:
     playlist = {
-        "title": nav(data, TITLE_TEXT),
+        "title": nav(
+            data,
+            TITLE_TEXT,
+            none_if_absent=True,  # rare but possible for playlist title to be missing
+        ),
         "playlistId": nav(data, TITLE + NAVIGATION_BROWSE_ID)[2:],
         "thumbnails": nav(data, THUMBNAIL_RENDERER),
     }


### PR DESCRIPTION
As seen in #805 , there was a case where a user had a "zombie" playlist stuck in their library with no title, tracks, or artwork, and `parse_playlist` was throwing a `KeyError` because of the missing title, causing `get_library_playlists` to throw an error.

<img width="1563" height="1277" alt="481334344-c5cc2b23-b0ba-42af-9dfe-fb93d5843cbc" src="https://github.com/user-attachments/assets/fa01dc6b-4352-41f7-8251-f48c302887dd" />

This fix just sets `none_if_absent=True` for the "title" attribute. I am hesitant to go a step further and make similar accomodations for other fields that might be missing, since the only field that I know for sure was missing from the response was "title". In my opinion I would rather wait for an occurence where it throws a KeyError on another field than start putting `none_if_absent` on everything. It's possible there was still a "thumbnails" attribute in the JSON even though the playlist didn't have a thumbnail.