### PR TITLE
`get_playlist`/`get_episodes_playlist`: fix metadata

### DIFF
--- a/tests/mixins/test_browsing.py
+++ b/tests/mixins/test_browsing.py
@@ -56,6 +56,7 @@ class TestBrowsing:
     def test_get_artist_albums(self, yt):
         artist = yt.get_artist("UCAeLFBCQS7FvI8PvBrWvSBg")
         results = yt.get_artist_albums(artist["albums"]["browseId"], artist["albums"]["params"])
+        assert all("artists" not in result for result in results)  # artist info is omitted from the results
         assert len(results) == 100
         results = yt.get_artist_albums(artist["singles"]["browseId"], artist["singles"]["params"])
         assert len(results) == 100

--- a/tests/mixins/test_playlists.py
+++ b/tests/mixins/test_playlists.py
@@ -80,6 +80,13 @@ class TestPlaylists:
         assert playlist["trackCount"] is None  # playlist has no trackCount
         assert len(playlist["tracks"]) >= 100
 
+    def test_get_playlist_author(self, yt):
+        playlist = yt.get_playlist("PL9tY0BWXOZFu4vlBOzIOmvT6wjYb2jNiV")
+        assert "artists" not in playlist  # shouldn't return the "artists" key from parse_song_runs
+        assert playlist["author"] == {"name": "Vevo", "id": "UC2pmfLm7iq6Ov1UwYrWYkZA"}
+        playlist = yt.get_playlist("RDCLAK5uy_l2pHac-aawJYLcesgTf67gaKU-B9ekk1o")
+        assert playlist["author"] == {"name": "YouTube Music", "id": None}
+
     @pytest.mark.parametrize("language", SUPPORTED_LANGUAGES)
     def test_get_playlist_languages(self, language):
         yt = YTMusic(language=language)

--- a/tests/mixins/test_podcasts.py
+++ b/tests/mixins/test_podcasts.py
@@ -49,3 +49,6 @@ class TestPodcasts:
     def test_get_episodes_playlist(self, yt_brand):
         playlist = yt_brand.get_episodes_playlist()
         assert len(playlist["episodes"]) > 90
+        assert playlist["description"]
+        assert playlist["year"]
+        assert playlist["author"]["id"] and playlist["author"]["name"]

--- a/ytmusicapi/mixins/playlists.py
+++ b/ytmusicapi/mixins/playlists.py
@@ -34,7 +34,10 @@ class PlaylistsMixin(MixinProtocol):
               "title": "New EDM This Week 03/13/2020",
               "thumbnails": [...]
               "description": "Weekly r/EDM new release roundup. Created with github.com/sigma67/spotifyplaylist_to_gmusic",
-              "author": "sigmatics",
+              "author": {
+                  "name": "sigmatics",
+                  "id": "..."
+              },
               "year": "2020",
               "duration": "6+ hours",
               "duration_seconds": 52651,

--- a/ytmusicapi/parsers/playlists.py
+++ b/ytmusicapi/parsers/playlists.py
@@ -26,15 +26,8 @@ def parse_playlist_header(response: JsonDict) -> JsonDict:
     playlist.update(parse_playlist_header_meta(header))
     if playlist["thumbnails"] is None:
         playlist["thumbnails"] = nav(header, THUMBNAIL_CROPPED, True)
-    playlist["description"] = nav(header, DESCRIPTION, True)
-    run_count = len(nav(header, SUBTITLE_RUNS))
-    if run_count > 1:
-        playlist["author"] = {
-            "name": nav(header, SUBTITLE2),
-            "id": nav(header, [*SUBTITLE_RUNS, 2, *NAVIGATION_BROWSE_ID], True),
-        }
-        if run_count == 5:
-            playlist["year"] = nav(header, SUBTITLE3)
+    playlist["description"] = nav(header, ["description", *DESCRIPTION_SHELF, *DESCRIPTION], True)
+    playlist["year"] = nav(header, SUBTITLE2)
 
     return playlist
 
@@ -47,6 +40,24 @@ def parse_playlist_header_meta(header: JsonDict) -> JsonDict:
         "title": "".join([run["text"] for run in header.get("title", {}).get("runs", [])]),
         "thumbnails": nav(header, THUMBNAILS),
     }
+    if "facepile" in header:
+        playlist_meta["author"] = {
+            "name": nav(header, ["facepile", "avatarStackViewModel", "text", "content"]),
+            "id": nav(
+                header,
+                [
+                    "facepile",
+                    "avatarStackViewModel",
+                    "rendererContext",
+                    "commandContext",
+                    "onTap",
+                    "innertubeCommand",
+                    "browseEndpoint",
+                    "browseId",
+                ],
+                True,
+            ),
+        }
     if "runs" in header["secondSubtitle"]:
         second_subtitle_runs = header["secondSubtitle"]["runs"]
         has_views = (len(second_subtitle_runs) > 3) * 2

--- a/ytmusicapi/parsers/songs.py
+++ b/ytmusicapi/parsers/songs.py
@@ -52,7 +52,7 @@ def parse_song_runs(runs: JsonList, skip_type_spec: bool = False) -> JsonDict:
     :param skip_type_spec: if true, skip the type specifier (like "Song", "Single", or "Album") that may appear before artists ("Song • Eminem"). Otherwise, that text item is parsed as an artist with no ID.
     """
 
-    parsed: JsonDict = {"artists": []}
+    parsed: JsonDict = {}
 
     # prevent type specifier from being parsed as an artist
     # it's the first run, separated from the actual artists by " • "
@@ -75,6 +75,7 @@ def parse_song_runs(runs: JsonList, skip_type_spec: bool = False) -> JsonDict:
             case "album":
                 parsed["album"] = data
             case "artist":
+                parsed["artists"] = parsed.get("artists", [])
                 parsed["artists"].append(data)
             case "views":
                 parsed["views"] = data


### PR DESCRIPTION
- `get_playlist` (non-audio) returns `author`

- `get_episodes_playlist` parses `description` and no longer returns `year` as the author name:

```diff
- "description": null,
- "author": {
-   "name": "2025",
-   "id": null
- },
+ "description": "The newest episodes from all your saved podcasts",
+ "author": {
+   "name": "Authed User",
+   "id": "..."
+ },
+ "year": "2025",
```

- `get_artist_albums` and `get_playlist` (non-audio) no longer return `"artists": []`