### PR TITLE
docs: Improve browser authentication instructions for Chrome

### DIFF
--- a/docs/source/setup/browser.rst
+++ b/docs/source/setup/browser.rst
@@ -14,8 +14,8 @@ To do so, follow these steps:
 - Open a new tab
 - Open the developer tools (Ctrl-Shift-I) and select the "Network" tab (Command-Option-I on MacOS)
 - Go to https://music.youtube.com and ensure you are logged in
-- Find an authenticated POST request with cookies (enable the Cookies column by right-clicking and selecting it in Header Options). The simplest way is to filter by ``/browse`` (or ``/get_setting_values``) using the search bar of the developer tools.
-  If you don't see the request, try scrolling down a bit or clicking on the library button in the top bar.
+- Find an authenticated POST request. The simplest way is to filter by ``/browse`` using the search bar of the developer tools.
+  If you don't see the request, try scrolling down a bit or clicking on the **Library** button in the top bar.
 
 .. raw:: html
 
@@ -40,18 +40,10 @@ To do so, follow these steps:
 
     - Verify that the request looks like this: **Status** 200, **Name** ``browse?...``
     - Click on the Name of any matching request. In the "Headers" tab, scroll to the section "Request headers" and copy everything starting from "accept: \*/\*" to the end of the section
-      - On new versions of Chrome, you can use "method\:POST has-request-header\:X-Goog-AuthUser" as a filter to narrow it down.  Then "Copy as fetch (Node.js)" can be used to get the headers in a more convenient format. In this case, copy everything between the curly braces after "headers: {" and before the closing curly brace.
-      - It should look like this:
-.. code-block:: json
+    - On new versions of Chrome, right click on the name and "Copy as fetch (Node.js)". Use a text editor to delete everything except the following:
 
-    {
-      "accept": "*/*",
-      "accept-encoding": "gzip, deflate, br",
-      "accept-language": "en-US,en;q=0.9",
-      ...
-      "x-youtube-client-name": "67",
-      "x-youtube-client-version": "2.20211021.00.00"
-    }
+.. literalinclude:: headers_auth.json.example
+  :language: JSON
 
 .. raw:: html
 
@@ -99,7 +91,7 @@ These credentials remain valid as long as your YTMusic browser session is valid 
 Manual file creation
 --------------------
 
-Alternatively, you can create your own file ``browser.json`` and paste the cookie:
+Alternatively, you can create your own file ``browser.json`` and paste the authentication and cookie:
 
 .. literalinclude:: headers_auth.json.example
   :language: JSON

--- a/docs/source/setup/headers_auth.json.example
+++ b/docs/source/setup/headers_auth.json.example
@@ -1,7 +1,6 @@
 {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:72.0) Gecko/20100101 Firefox/72.0",
     "Accept": "*/*",
-    "Accept-Language": "en-US,en;q=0.5",
+    "Authorization": "PASTE_AUTHORIZATION",
     "Content-Type": "application/json",
     "X-Goog-AuthUser": "0",
     "x-origin": "https://music.youtube.com",


### PR DESCRIPTION
Clarified the steps for obtaining a browser-generated auth header and added missing details about the headers format.
Closes #832 