### PR TITLE
remove flaky test (`test_get_playlist_unavailable`)

### DIFF
--- a/tests/mixins/test_playlists.py
+++ b/tests/mixins/test_playlists.py
@@ -97,13 +97,6 @@ class TestPlaylists:
         assert playlist["trackCount"] is None  # playlist has no trackCount
         assert len(playlist["tracks"]) >= 100
 
-    def test_get_playlist_unavailable(self, yt):
-        playlist_id = "OLAK5uy_mnDXXKVcY1Z_HKY00a_ZBrnE679EzsM50"
-        playlist = yt.get_playlist(playlist_id)
-        # in case this show is unavailable in the current region, we should get the ID without playNavigationEndpoint
-        assert playlist["id"] == playlist_id
-        assert len(playlist["tracks"]) == 35
-
     def test_get_playlist_author(self, yt):
         playlist = yt.get_playlist("PL9tY0BWXOZFu4vlBOzIOmvT6wjYb2jNiV")
         assert "artists" not in playlist  # shouldn't return the "artists" key from parse_song_runs


### PR DESCRIPTION
`/browse` may no longer return content for unavailable releases