### PR TITLE
feat: add votes support to get_playlist

### DIFF
--- a/tests/mixins/test_playlists.py
+++ b/tests/mixins/test_playlists.py
@@ -48,6 +48,12 @@ class TestPlaylists:
                 if track["videoType"] == "MUSIC_VIDEO_TYPE_ATV":
                     assert isinstance(track["album"]["name"], str) and track["album"]["name"]
 
+            # Collaborative playlists should have voteStatus on tracks
+            if "collaborators" in playlist:
+                for track in playlist["tracks"]:
+                    assert "voteStatus" in track
+                    assert isinstance(track["voteStatus"], int)
+
     @pytest.mark.parametrize(
         "playlist_id, tracks_len, related_len",
         [

--- a/ytmusicapi/mixins/playlists.py
+++ b/ytmusicapi/mixins/playlists.py
@@ -107,12 +107,15 @@ class PlaylistsMixin(MixinProtocol):
                     "pin": "AB9zfpImL2k...",
                     "unpin": "AB9zfpJt6pA..."
                   },
+                  "voteStatus": 1759349873
 
               ]
             }
 
         The setVideoId is the unique id of this playlist item and
-        needed for moving/removing playlist items
+        needed for moving/removing playlist items.
+
+        For playlists with voting enabled, tracks will contain ``voteStatus`` with a vote sort value.
 
         Collaborative playlists replace ``author`` with limited data about ``collaborators``::
             {

--- a/ytmusicapi/mixins/playlists.py
+++ b/ytmusicapi/mixins/playlists.py
@@ -115,7 +115,9 @@ class PlaylistsMixin(MixinProtocol):
         The setVideoId is the unique id of this playlist item and
         needed for moving/removing playlist items.
 
-        For playlists with voting enabled, tracks will contain ``voteStatus`` with a vote sort value.
+        For collaborative playlists with voting enabled, tracks will contain ``voteStatus``.
+        This is an internal sort value used by YouTube Music to order tracks by votes
+        (higher values appear first when sorted by votes). It is not a direct vote count.
 
         Collaborative playlists replace ``author`` with limited data about ``collaborators``::
             {

--- a/ytmusicapi/parsers/playlists.py
+++ b/ytmusicapi/parsers/playlists.py
@@ -150,6 +150,12 @@ def parse_playlist_item(
 ) -> JsonDict | None:
     videoId = setVideoId = None
     like = None
+    voteStatus = None
+
+    # Extract vote status from playlistItemData if present (for playlists with voting enabled)
+    if "playlistItemData" in data:
+        playlist_item_data = data["playlistItemData"]
+        voteStatus = playlist_item_data.get("voteSortValue")
 
     # if the item has a menu, find its setVideoId
     if "menu" in data:
@@ -284,6 +290,8 @@ def parse_playlist_item(
         song["duration_seconds"] = parse_duration(duration)
     if setVideoId:
         song["setVideoId"] = setVideoId
+    if voteStatus is not None:
+        song["voteStatus"] = voteStatus
 
     return song
 

--- a/ytmusicapi/parsers/playlists.py
+++ b/ytmusicapi/parsers/playlists.py
@@ -150,12 +150,7 @@ def parse_playlist_item(
 ) -> JsonDict | None:
     videoId = setVideoId = None
     like = None
-    voteStatus = None
-
-    # Extract vote status from playlistItemData if present (for playlists with voting enabled)
-    if "playlistItemData" in data:
-        playlist_item_data = data["playlistItemData"]
-        voteStatus = playlist_item_data.get("voteSortValue")
+    voteStatus = nav(data, ["playlistItemData", "voteSortValue"], True)
 
     # if the item has a menu, find its setVideoId
     if "menu" in data:


### PR DESCRIPTION
## Summary
Adds support for retrieving playlist votes in the `get_playlist` method. For playlists with voting enabled, the `voteSortValue` field from `playlistItemData` is now parsed and included as `voteStatus` in track objects.

Fixes #871

## Changes
- Parse `voteSortValue` from `playlistItemData` in `parse_playlist_item()`
- Add `voteStatus` field to playlist track objects when voting data is present
- Update docstring in `get_playlist` to document the new field

## Testing
- [x] Existing tests pass (all 4 `test_get_playlist` parameterized tests)
- [x] Verified `voteStatus` is correctly parsed from collaborative playlist test data
- [x] Verified `voteStatus` is correctly parsed from audio playlist test data
- [x] Verified regular playlists without voting don't have the field (as expected)

## AI Transparency
This PR was created with the assistance of AI (Claude by Anthropic) for code generation and review.