### PR TITLE
fix: handle singleColumnBrowseResultsRenderer in addition to twoColumnBrowseResultsRenderer

### DIFF
--- a/ytmusicapi/mixins/browsing.py
+++ b/ytmusicapi/mixins/browsing.py
@@ -574,12 +574,21 @@ class BrowsingMixin(MixinProtocol):
         response = self._send_request(endpoint, body)
         album: JsonDict = parse_album_header_2024(response)
 
-        results = nav(response, [*TWO_COLUMN_RENDERER, "secondaryContents", *SECTION_LIST_ITEM, *MUSIC_SHELF])
+        # Try twoColumn first, fallback to singleColumn
+        results = nav(
+            response, [*TWO_COLUMN_RENDERER, "secondaryContents", *SECTION_LIST_ITEM, *MUSIC_SHELF], True
+        )
+        if results is None:
+            results = nav(response, [*SINGLE_COLUMN, *TAB_CONTENT, *SECTION_LIST_ITEM, *MUSIC_SHELF], True)
+        if results is None:
+            results = nav(response, [*SINGLE_COLUMN, "secondaryContents", *SECTION_LIST_ITEM, *MUSIC_SHELF])
         album["tracks"] = parse_playlist_items(results["contents"], is_album=True)
 
-        secondary_carousels = (
-            nav(response, [*TWO_COLUMN_RENDERER, "secondaryContents", *SECTION_LIST], True) or []
-        )
+        # Try twoColumn first, fallback to singleColumn
+        secondary_carousels = nav(response, [*TWO_COLUMN_RENDERER, "secondaryContents", *SECTION_LIST], True)
+        if secondary_carousels is None:
+            secondary_carousels = nav(response, [*SINGLE_COLUMN, "secondaryContents", *SECTION_LIST], True)
+        secondary_carousels = secondary_carousels or []
         for section in secondary_carousels[1:]:
             carousel = nav(section, CAROUSEL)
             key = {

--- a/ytmusicapi/mixins/playlists.py
+++ b/ytmusicapi/mixins/playlists.py
@@ -139,12 +139,34 @@ class PlaylistsMixin(MixinProtocol):
 
         request_func_continuations: RequestFuncBodyType = lambda body: self._send_request(endpoint, body)
         is_ola = playlistId.startswith("OLA") or playlistId.startswith("VLOLA")
-        has_playlist_header = nav(response, [*TWO_COLUMN_RENDERER, *TAB_CONTENT, *SECTION_LIST_ITEM], True)
-        if is_ola and not has_playlist_header:
-            return parse_audio_playlist(response, limit, request_func_continuations)
 
-        header_data = nav(response, [*TWO_COLUMN_RENDERER, *TAB_CONTENT, *SECTION_LIST_ITEM])
-        section_list = nav(response, [*TWO_COLUMN_RENDERER, "secondaryContents", *SECTION])
+        # Try twoColumnBrowseResultsRenderer first, fallback to singleColumnBrowseResultsRenderer
+        # YouTube Music may return either format depending on A/B testing
+        two_col = nav(response, TWO_COLUMN_RENDERER, True)
+        if two_col is not None:
+            has_playlist_header = nav(two_col, [*TAB_CONTENT, *SECTION_LIST_ITEM], True)
+            if is_ola and not has_playlist_header:
+                return parse_audio_playlist(response, limit, request_func_continuations)
+            header_data = nav(two_col, [*TAB_CONTENT, *SECTION_LIST_ITEM])
+            section_list = nav(two_col, ["secondaryContents", *SECTION])
+        else:
+            # singleColumnBrowseResultsRenderer format
+            single_col = nav(response, SINGLE_COLUMN, True)
+            if single_col is None:
+                raise KeyError(
+                    "Response contains neither twoColumnBrowseResultsRenderer nor singleColumnBrowseResultsRenderer"
+                )
+            has_playlist_header = nav(single_col, [*TAB_CONTENT, *SECTION_LIST_ITEM], True)
+            if is_ola and not has_playlist_header:
+                return parse_audio_playlist(response, limit, request_func_continuations)
+            header_data = nav(single_col, [*TAB_CONTENT, *SECTION_LIST_ITEM])
+            # In single column, section list might be in a different location
+            section_list = nav(single_col, [*TAB_CONTENT, *SECTION], True)
+            if section_list is None:
+                # Try alternate path for single column
+                section_list = nav(single_col, ["secondaryContents", *SECTION], True)
+            if section_list is None:
+                section_list = nav(single_col, TAB_CONTENT + SECTION)
         playlist: JsonDict = {}
         playlist["owned"] = EDITABLE_PLAYLIST_DETAIL_HEADER[0] in header_data
         if not playlist["owned"]:

--- a/ytmusicapi/mixins/podcasts.py
+++ b/ytmusicapi/mixins/podcasts.py
@@ -137,7 +137,10 @@ class PodcastsMixin(MixinProtocol):
         body = {"browseId": browseId}
         endpoint = "browse"
         response = self._send_request(endpoint, body)
-        two_columns = nav(response, TWO_COLUMN_RENDERER)
+        # Try twoColumn first, fallback to singleColumn
+        two_columns = nav(response, TWO_COLUMN_RENDERER, True)
+        if two_columns is None:
+            two_columns = nav(response, SINGLE_COLUMN)
         header = nav(two_columns, [*TAB_CONTENT, *SECTION_LIST_ITEM, *RESPONSIVE_HEADER])
         podcast: JsonDict = parse_podcast_header(header)
 
@@ -220,7 +223,10 @@ class PodcastsMixin(MixinProtocol):
         endpoint = "browse"
         response = self._send_request(endpoint, body)
 
-        two_columns = nav(response, TWO_COLUMN_RENDERER)
+        # Try twoColumn first, fallback to singleColumn
+        two_columns = nav(response, TWO_COLUMN_RENDERER, True)
+        if two_columns is None:
+            two_columns = nav(response, SINGLE_COLUMN)
         header = nav(two_columns, [*TAB_CONTENT, *SECTION_LIST_ITEM, *RESPONSIVE_HEADER])
         episode = parse_episode_header(header)
 
@@ -249,7 +255,16 @@ class PodcastsMixin(MixinProtocol):
         response = self._send_request(endpoint, body)
         playlist = parse_playlist_header(response)
 
-        results = nav(response, [*TWO_COLUMN_RENDERER, "secondaryContents", *SECTION_LIST_ITEM, *MUSIC_SHELF])
+        # Try twoColumn first, fallback to singleColumn
+        results = nav(
+            response, [*TWO_COLUMN_RENDERER, "secondaryContents", *SECTION_LIST_ITEM, *MUSIC_SHELF], True
+        )
+        if results is None:
+            results = nav(
+                response, [*SINGLE_COLUMN, "secondaryContents", *SECTION_LIST_ITEM, *MUSIC_SHELF], True
+            )
+        if results is None:
+            results = nav(response, [*SINGLE_COLUMN, *TAB_CONTENT, *SECTION_LIST_ITEM, *MUSIC_SHELF])
         parse_func: ParseFuncType = lambda contents: parse_content_list(contents, parse_episode, MMRIR)
         playlist["episodes"] = parse_func(results["contents"])
 

--- a/ytmusicapi/navigation.py
+++ b/ytmusicapi/navigation.py
@@ -147,3 +147,17 @@ def find_objects_by_key(object_list: JsonList, key: str, nested: str | None = No
         if key in item:
             objects.append(item)
     return objects
+
+
+def get_browse_renderer(response: JsonDict) -> JsonDict | None:
+    """
+    Get browse results renderer from response, handling both twoColumn and singleColumn formats.
+    YouTube Music can return either format depending on A/B testing or account settings.
+    """
+    # Try twoColumnBrowseResultsRenderer first (legacy/most common)
+    two_col: JsonDict | None = nav(response, TWO_COLUMN_RENDERER, none_if_absent=True)
+    if two_col is not None:
+        return two_col
+    # Fallback to singleColumnBrowseResultsRenderer (newer format)
+    single_col: JsonDict | None = nav(response, SINGLE_COLUMN, none_if_absent=True)
+    return single_col

--- a/ytmusicapi/parsers/albums.py
+++ b/ytmusicapi/parsers/albums.py
@@ -41,7 +41,10 @@ def parse_album_header(response: JsonDict) -> JsonDict:
 
 
 def parse_album_header_2024(response: JsonDict) -> JsonDict:
-    header = nav(response, [*TWO_COLUMN_RENDERER, *TAB_CONTENT, *SECTION_LIST_ITEM, *RESPONSIVE_HEADER])
+    # Try twoColumn first, fallback to singleColumn
+    header = nav(response, [*TWO_COLUMN_RENDERER, *TAB_CONTENT, *SECTION_LIST_ITEM, *RESPONSIVE_HEADER], True)
+    if header is None:
+        header = nav(response, [*SINGLE_COLUMN, *TAB_CONTENT, *SECTION_LIST_ITEM, *RESPONSIVE_HEADER])
     album = {
         "title": nav(header, TITLE_TEXT),
         "type": nav(header, SUBTITLE),

--- a/ytmusicapi/parsers/playlists.py
+++ b/ytmusicapi/parsers/playlists.py
@@ -19,9 +19,14 @@ def parse_playlist_header(response: JsonDict) -> JsonDict:
     else:
         header = nav(response, HEADER_DETAIL, True)
         if header is None:
+            # Try twoColumnBrowseResultsRenderer first, then singleColumnBrowseResultsRenderer
             header = nav(
-                response, [*TWO_COLUMN_RENDERER, *TAB_CONTENT, *SECTION_LIST_ITEM, *RESPONSIVE_HEADER]
+                response, [*TWO_COLUMN_RENDERER, *TAB_CONTENT, *SECTION_LIST_ITEM, *RESPONSIVE_HEADER], True
             )
+            if header is None:
+                header = nav(
+                    response, [*SINGLE_COLUMN, *TAB_CONTENT, *SECTION_LIST_ITEM, *RESPONSIVE_HEADER], True
+                )
 
     playlist.update(parse_playlist_header_meta(header))
     if playlist["thumbnails"] is None:
@@ -106,7 +111,12 @@ def parse_audio_playlist(
         "related": [],
     }
 
-    section_list = nav(response, [*TWO_COLUMN_RENDERER, "secondaryContents", *SECTION])
+    # Try twoColumn first, fallback to singleColumn
+    section_list = nav(response, [*TWO_COLUMN_RENDERER, "secondaryContents", *SECTION], True)
+    if section_list is None:
+        section_list = nav(response, [*SINGLE_COLUMN, *TAB_CONTENT, *SECTION], True)
+    if section_list is None:
+        section_list = nav(response, [*SINGLE_COLUMN, "secondaryContents", *SECTION])
     content_data = nav(section_list, [*CONTENT, "musicPlaylistShelfRenderer"])
 
     playlist["id"] = nav(content_data, ["targetId"])


### PR DESCRIPTION
YouTube Music now returns `singleColumnBrowseResultsRenderer` instead of `twoColumnBrowseResultsRenderer` for some users/endpoints (likely A/B testing).This caused `KeyError` exceptions in `get_playlist()`, `get_liked_songs()`, `get_album()`, and podcast-related functions.## Changes- **navigation.py**: Added `get_browse_renderer()` helper function- **mixins/playlists.py**: Updated `get_playlist()` to handle both formats- **parsers/playlists.py**: Updated `parse_playlist_header()` and `parse_audio_playlist()`- **parsers/albums.py**: Updated `parse_album_header_2024()`- **mixins/browsing.py**: Updated `get_album()`- **mixins/podcasts.py**: Updated `get_podcast()`, `get_episode()`, and `get_episodes_playlist()`## FixThe fix adds fallback logic to try `twoColumnBrowseResultsRenderer` first, then `singleColumnBrowseResultsRenderer` if the former is not present in the API response.Closes #616