### PR TITLE
feature: add get_song_credits (#883)

### DIFF
--- a/docs/source/reference/browsing.rst
+++ b/docs/source/reference/browsing.rst
@@ -15,3 +15,4 @@ Browsing
 .. automethod:: YTMusic.get_lyrics
 .. automethod:: YTMusic.get_tasteprofile
 .. automethod:: YTMusic.set_tasteprofile
+.. automethod:: YTMusic.get_song_credits

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,3 +73,9 @@ def fixture_yt_brand(config) -> YTMusic:
 @pytest.fixture(name="yt_empty")
 def fixture_yt_empty(config) -> YTMusic:
     return YTMusic(config["auth"]["headers_empty"], config["auth"]["brand_account_empty"])
+
+
+@pytest.fixture(name="sample_credits")
+def fixture_sample_credits() -> str:
+    """KANGTA - The Cure"""
+    return "MPTCJpKLGcWBJ5Y"

--- a/tests/mixins/test_browsing.py
+++ b/tests/mixins/test_browsing.py
@@ -134,6 +134,9 @@ class TestBrowsing:
         assert album["audioPlaylistId"] is not None
         assert album["tracks"][0]["trackNumber"] == 1
         assert "feedbackTokens" in album["tracks"][0]
+        assert all(
+            item["creditsBrowseId"] and item["creditsBrowseId"].startswith("MPTC") for item in album["tracks"]
+        )
         album = yt.get_album("MPREb_BQZvl3BFGay")
         assert album["audioPlaylistId"] is not None
         assert len(album["tracks"]) == 7
@@ -259,3 +262,21 @@ class TestBrowsing:
         results = yt_auth.get_search_suggestions("b", detailed_runs=True)
         assert len(results) > 0
         assert any(not item["fromHistory"] for item in results)
+
+    def test_get_song_credits(self, yt, sample_credits):
+        credits = yt.get_song_credits(sample_credits)
+
+        SECTIONS = {"performed_by", "written_by", "produced_by", "music_metadata_provided_by"}
+
+        for section in SECTIONS:
+            assert section in credits
+            assert credits[section] is not None
+            assert len(credits[section]) > 0
+            assert all(isinstance(item, str) and item for item in credits[section])
+            assert "\n" not in credits[section]
+
+        assert len(credits["performed_by"]) == 12
+        assert credits["performed_by"][0] == "KANGTA"
+        assert credits["written_by"][4] == "Eirik Røland"
+        assert credits["produced_by"][1] == "David Zandén"
+        assert credits["music_metadata_provided_by"][0] == "SM Entertainment"

--- a/tests/mixins/test_playlists.py
+++ b/tests/mixins/test_playlists.py
@@ -55,7 +55,7 @@ class TestPlaylists:
             ("RDCLAK5uy_nfjzC9YC1NVPPZHvdoAtKVBOILMDOuxOs", 200, 10),
             ("PLj4BSJLnVpNyIjbCWXWNAmybc97FXLlTk", 200, 0),  # no related tracks
             ("PL6bPxvf5dW5clc3y9wAoslzqUrmkZ5c-u", 1000, 10),  # very large
-            ("PL5ZNf-B8WWSZFIvpJWRjgt7iRqWT7_KF1", 10, 10),  # track duration > 1k hours
+            ("PLf6FAPI9j8OOAwvsj_FdO5tyd0GcPLnkm", 200, 0),  # track duration > 1k hours
         ],
     )
     def test_get_playlist_foreign(self, yt_oauth, playlist_id, tracks_len, related_len):

--- a/ytmusicapi/mixins/browsing.py
+++ b/ytmusicapi/mixins/browsing.py
@@ -552,6 +552,7 @@ class BrowsingMixin(MixinProtocol):
                     "pin": "AB9zfpJ...",
                     "unpin": "AB9zfpL..."
                   },
+                  "creditsBrowseId": "MPTCiKLU7z_xdYQ"
                 }
               ],
               "other_versions": [
@@ -594,6 +595,56 @@ class BrowsingMixin(MixinProtocol):
             album["tracks"][i]["artists"] = album["tracks"][i]["artists"] or album["artists"]
 
         return album
+
+    def get_song_credits(self, browseId: str) -> JsonDict:
+        """
+        Get credits for a song. Returned entries are not fixed by YouTube and may vary
+        between songs, but common ones include ``performed_by``, ``written_by`` ,
+        ``produced_by`` and ``music_metadata_provided_by``.
+
+        :param browseId: browseId for the credits of a song, for example returned as ``creditsBrowseId`` in the tracks of :py:func:`get_album`
+        :return: Dictionary with credit sections.
+
+        Example::
+
+            {
+              "performed_by": [
+                "Eminem",
+                "Beyoncé"
+              ],
+              "written_by": [
+                "Marshall Mathers",
+                "Beyoncé Knowles",
+                "Holly Hafermann"
+              ],
+              "produced_by": [
+                "Rick Rubin"
+              ],
+              "music_metadata_provided_by": [
+                "Eminem Catalog PS"
+              ]
+            }
+        """
+        if not browseId or not browseId.startswith("MPTC"):
+            raise YTMusicUserError("Invalid song credits browseId provided, must start with MPTC.")
+
+        body = {"browseId": browseId}
+        endpoint = "browse"
+        response = self._send_request(endpoint, body)
+
+        credits: JsonDict = {}
+        sections = nav(response, CREDITS_SECTIONS)
+        for section in sections:
+            section_data = section["dismissableDialogContentSectionRenderer"]
+
+            section_pretty_name: str = nav(section_data, TITLE_TEXT)
+            section_snake_case_name = section_pretty_name.lower().replace(" ", "_")
+
+            credits[section_snake_case_name] = []
+            for item in nav(section_data, SUBTITLE_RUNS)[::2]:
+                credits[section_snake_case_name].append(item["text"])
+
+        return credits
 
     def get_song(self, videoId: str, signatureTimestamp: int | None = None) -> JsonDict:
         """

--- a/ytmusicapi/mixins/playlists.py
+++ b/ytmusicapi/mixins/playlists.py
@@ -107,7 +107,7 @@ class PlaylistsMixin(MixinProtocol):
                     "pin": "AB9zfpImL2k...",
                     "unpin": "AB9zfpJt6pA..."
                   },
-
+                  "creditsBrowseId": "MPTCekz1IJ9I0sw"
               ]
             }
 

--- a/ytmusicapi/navigation.py
+++ b/ytmusicapi/navigation.py
@@ -101,6 +101,14 @@ TIMESTAMPED_LYRICS = [
     "timedLyricsModel",
     "lyricsData",
 ]
+CREDITS_SECTIONS = [
+    "onResponseReceivedActions",
+    0,
+    "openPopupAction",
+    "popup",
+    "dismissableDialogRenderer",
+    "sections",
+]
 
 
 @overload

--- a/ytmusicapi/parsers/playlists.py
+++ b/ytmusicapi/parsers/playlists.py
@@ -148,7 +148,7 @@ def parse_playlist_item(
     is_album: bool = False,
     is_collaborative: bool = False,
 ) -> JsonDict | None:
-    videoId = setVideoId = None
+    videoId = setVideoId = creditsBrowseId = None
     like = None
 
     # if the item has a menu, find its setVideoId
@@ -161,6 +161,10 @@ def parse_playlist_item(
                     videoId = nav(
                         menu_service, ["playlistEditEndpoint", "actions", 0, "removedVideoId"], True
                     )
+            elif MNIR in item:
+                maybe_credits_browse_id = nav(item, [MNIR, *NAVIGATION_BROWSE_ID], True)
+                if maybe_credits_browse_id and maybe_credits_browse_id.startswith("MPTC"):
+                    creditsBrowseId = maybe_credits_browse_id
 
     song_menu_data = {"inLibrary": None, "pinnedToListenAgain": None} | parse_song_menu_data(data)
 
@@ -284,6 +288,8 @@ def parse_playlist_item(
         song["duration_seconds"] = parse_duration(duration)
     if setVideoId:
         song["setVideoId"] = setVideoId
+    if creditsBrowseId:
+        song["creditsBrowseId"] = creditsBrowseId
 
     return song
 


### PR DESCRIPTION
### Changes:
- Adds the new function `get_song_credits` to fetch the credits of a song. Credits have their own browseId prefixed by `MPTC`.
- Updates the `parse_playlist_item` parser to return the `browseId` for the credits of a song in the response of `get_album` and `get_playlist.

### Failing tests:
- [x] Replaced long playlist with new one since [the playlist](https://music.youtube.com/playlist?list=PL5ZNf-B8WWSZFIvpJWRjgt7iRqWT7_KF1) doesn't seem to work anymore
- [ ] `test_search_ignore_spelling` finds [this](https://music.youtube.com/browse/VLOLAK5uy_myMTfH6AZxShPlS77LUPkMACmtl22Sw-M) relatively new playlist which seems to have corrupt metadata on YouTube's site? The duration is listed as "0+" hours 

Feature Request: #883 