### PR TITLE
fix: browser auth detection and unexpected OAuth token fields

### DIFF
--- a/ytmusicapi/auth/auth_parse.py
+++ b/ytmusicapi/auth/auth_parse.py
@@ -55,14 +55,19 @@ def determine_auth_type(auth_headers: CaseInsensitiveDict[str]) -> AuthType:
     :param auth_headers: auth headers dict
     :return: AuthType enum
     """
-    auth_type = AuthType.OAUTH_CUSTOM_CLIENT
-    if OAuthToken.is_oauth(auth_headers):
-        auth_type = AuthType.OAUTH_CUSTOM_CLIENT
-
     if authorization := auth_headers.get("authorization"):
         if "SAPISIDHASH" in authorization:
-            auth_type = AuthType.BROWSER
-        elif authorization.startswith("Bearer"):
-            auth_type = AuthType.OAUTH_CUSTOM_FULL
+            return AuthType.BROWSER
+        if authorization.startswith("Bearer"):
+            return AuthType.OAUTH_CUSTOM_FULL
 
-    return auth_type
+    if OAuthToken.is_oauth(auth_headers):
+        return AuthType.OAUTH_CUSTOM_CLIENT
+
+    # Browser auth files contain cookies with SAPISID but no authorization
+    # header (it's computed at request time from the SAPISID cookie).
+    cookie = auth_headers.get("cookie", "")
+    if "SAPISID" in cookie:
+        return AuthType.BROWSER
+
+    return AuthType.OAUTH_CUSTOM_CLIENT

--- a/ytmusicapi/auth/oauth/token.py
+++ b/ytmusicapi/auth/oauth/token.py
@@ -74,6 +74,10 @@ class OAuthToken(Token):
             with open(file_path, encoding="utf-8") as json_file:
                 file_pack = json.load(json_file)
 
+        # Filter to recognized Token fields — previously saved tokens may
+        # contain extra fields from Google's OAuth response.
+        known_fields = set(Token.members())
+        file_pack = {k: v for k, v in file_pack.items() if k in known_fields}
         return cls(**file_pack)
 
 
@@ -128,7 +132,12 @@ class RefreshingToken(OAuthToken):
             webbrowser.open(url)
         input(f"Go to {url} , finish the login flow and press Enter when done, Ctrl-C to abort")
         raw_token = credentials.token_from_code(code["device_code"])
-        ref_token = cls(credentials=credentials, **raw_token)
+        # Filter to only recognized Token fields — Google's OAuth response may
+        # include additional fields (e.g. refresh_token_expires_in) that are
+        # not part of the Token dataclass.
+        known_fields = set(Token.members())
+        filtered_token = {k: v for k, v in raw_token.items() if k in known_fields}
+        ref_token = cls(credentials=credentials, **filtered_token)
         ref_token.update(ref_token.as_dict())
         if to_file:
             ref_token.local_cache = Path(to_file)


### PR DESCRIPTION
## Summary

Two fixes for authentication issues in ytmusicapi 1.11.5:

### 1. `determine_auth_type` misidentifies browser auth as `OAUTH_CUSTOM_CLIENT`

Browser auth files created via `ytmusicapi setup` contain cookies with SAPISID but no `authorization` header (it's computed at request time from the SAPISID cookie). The current implementation defaults to `OAUTH_CUSTOM_CLIENT` when no `authorization` header is present, which causes the constructor to require `oauth_credentials` and reject valid browser auth files.

**Fix:** Check for SAPISID in cookies as a fallback when neither an `authorization` header nor OAuth token fields are found. Also restructured the function to use early returns for clarity.

### 2. Google's OAuth response now includes `refresh_token_expires_in` (Fixes #887)

Google recently added a `refresh_token_expires_in` field to the OAuth device flow token response. Since `Token` is a strict dataclass, passing this unexpected field causes:

```
TypeError: RefreshingToken.__init__() got an unexpected keyword argument 'refresh_token_expires_in'
```

**Fix:** Filter to recognized `Token` fields before constructing the token object, both in:
- `RefreshingToken.prompt_for_token()` — when creating new tokens from the OAuth flow
- `OAuthToken.from_json()` — when loading previously saved tokens that may contain the extra field

This approach is forward-compatible: any future fields Google adds to the response will be safely ignored.

## Testing

- Verified browser auth detection works correctly with SAPISID cookies
- Verified OAuth device flow completes without `refresh_token_expires_in` error
- Verified previously saved token files with extra fields load correctly

## Changes

- `ytmusicapi/auth/auth_parse.py` — restructured `determine_auth_type` with SAPISID cookie detection
- `ytmusicapi/auth/oauth/token.py` — filtered unknown fields in `prompt_for_token` and `from_json`