### PR TITLE
Handle artist album entries with missing subtitle data

### DIFF
--- a/ytmusicapi/parsers/browsing.py
+++ b/ytmusicapi/parsers/browsing.py
@@ -65,8 +65,12 @@ def parse_content_list(results: JsonList, parse_func: ParseFuncDictType, key: st
 def parse_album(result: JsonDict) -> JsonDict:
     album = {
         "title": nav(result, TITLE_TEXT),
-        "type": nav(result, SUBTITLE),
-        "artists": [parse_id_name(x) for x in nav(result, ["subtitle", "runs"]) if "navigationEndpoint" in x],
+        "type": nav(result, SUBTITLE, True),
+        "artists": [
+            parse_id_name(x)
+            for x in (nav(result, ["subtitle", "runs"], True) or [])
+            if "navigationEndpoint" in x
+        ],
         "browseId": nav(result, TITLE + NAVIGATION_BROWSE_ID),
         "audioPlaylistId": parse_album_playlistid_if_exists(nav(result, THUMBNAIL_OVERLAY_NAVIGATION, True)),
         "thumbnails": nav(result, THUMBNAIL_RENDERER),


### PR DESCRIPTION
It's nice to see this project alive and in development.

## Problem

`get_artist()` can fail on real artist pages when an album card has an empty `subtitle` object instead of
`subtitle.runs`.

Example:

```python
ytmusic.get_artist("UCNVZwsvDWB_VtJPvAvNbLIA")
```

Artist is Ivory Moon.

Current error:

KeyError: "Unable to find 'runs' using path ['subtitle', 'runs', 0, 'text'] ..."

## Cause

On the Ivory Moon artist page, the Albums shelf contains Lunar Gateway with:

"subtitle": {}

parse_album() currently assumes subtitle.runs always exists for:

- album type
- album artists

## Fix

Make subtitle parsing optional in parse_album():

- type uses nav(..., True)
- artists falls back to [] when subtitle.runs is missing

## Result

After this change, get_artist("UCNVZwsvDWB_VtJPvAvNbLIA") returns successfully.

The affected album still has missing subtitle-derived metadata, but the full artist response no longer crashes.