### PR TITLE
get_playlist: support continuations for playlists sorted by "Top voted"

### DIFF
--- a/tests/mixins/test_playlists.py
+++ b/tests/mixins/test_playlists.py
@@ -9,6 +9,7 @@ from ytmusicapi import YTMusic
 from ytmusicapi.constants import SUPPORTED_LANGUAGES
 from ytmusicapi.enums import ResponseStatus
 from ytmusicapi.exceptions import YTMusicUserError
+from ytmusicapi.models.content.enums import PlaylistSortOrder
 
 
 class TestPlaylists:
@@ -156,17 +157,30 @@ class TestPlaylists:
         assert len(playlist_id) == 34, "Playlist creation failed"
 
         try:
-            response = yt_oauth.edit_playlist(playlist_id, collaboration=True)
+            response = yt_oauth.edit_playlist(
+                playlist_id, collaboration=True, sortOrder=PlaylistSortOrder.TOP_VOTED
+            )
             assert response["status"] == ResponseStatus.SUCCEEDED
+            join_collaboration_token = response["joinCollaborationToken"]
+
+            TRACK_COUNT = 101
+            response = yt_oauth.add_playlist_items(
+                playlist_id, ["lYBUbBu4W08"] * TRACK_COUNT, duplicates=True
+            )
+            assert response["status"] == ResponseStatus.SUCCEEDED, "Adding playlist items failed"
+
             time.sleep(15)  # wait for collaboration to be enabled
             assert (
-                yt_brand.join_collaborative_playlist(playlist_id, response["joinCollaborationToken"])
+                yt_brand.join_collaborative_playlist(playlist_id, join_collaboration_token)
                 == ResponseStatus.SUCCEEDED
             )
 
-            playlist = yt_oauth.get_playlist(playlist_id)
+            playlist = yt_oauth.get_playlist(playlist_id, limit=None)
             assert len(playlist["collaborators"]["avatars"]) == 2
             assert "author" not in playlist
+
+            # we should have continuations for large vote-sorted playlists
+            assert len(playlist["tracks"]) == TRACK_COUNT
 
             assert yt_oauth.edit_playlist(playlist_id, collaboration=False) == ResponseStatus.SUCCEEDED
             time.sleep(3)

--- a/ytmusicapi/continuations.py
+++ b/ytmusicapi/continuations.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 from ytmusicapi.navigation import nav
 from ytmusicapi.type_alias import (
@@ -12,11 +12,29 @@ from ytmusicapi.type_alias import (
 )
 
 CONTINUATION_TOKEN = ["continuationItemRenderer", "continuationEndpoint", "continuationCommand", "token"]
+COMMAND_EXECUTOR_COMMANDS = [
+    "continuationItemRenderer",
+    "continuationEndpoint",
+    "commandExecutorCommand",
+    "commands",
+]
 CONTINUATION_ITEMS = ["onResponseReceivedActions", 0, "appendContinuationItemsAction", "continuationItems"]
 
 
 def get_continuation_token(results: JsonList) -> str | None:
-    return nav(results[-1], CONTINUATION_TOKEN, True)
+    last_result = results[-1]
+
+    if token := nav(last_result, CONTINUATION_TOKEN, True):
+        return cast(str, token)
+
+    # continuation tokens may be nested in a commandExecutorCommand list
+    # (alongside playlistVotingRefreshPopupCommand, for example)
+    commands = nav(last_result, COMMAND_EXECUTOR_COMMANDS, True) or []
+    for command in commands:
+        if nav(command, ["continuationCommand", "request"], True) == "CONTINUATION_REQUEST_TYPE_BROWSE":
+            return cast(str, nav(command, ["continuationCommand", "token"]))
+
+    return None
 
 
 def get_continuations_2025(

--- a/ytmusicapi/mixins/playlists.py
+++ b/ytmusicapi/mixins/playlists.py
@@ -4,6 +4,7 @@ from ytmusicapi.continuations import *
 from ytmusicapi.enums import ResponseStatus
 from ytmusicapi.exceptions import YTMusicUserError
 from ytmusicapi.helpers import sum_total_duration
+from ytmusicapi.models.content.enums import PlaylistSortOrder
 from ytmusicapi.navigation import *
 from ytmusicapi.parsers.browsing import parse_content_list, parse_playlist
 from ytmusicapi.parsers.playlists import *
@@ -313,6 +314,7 @@ class PlaylistsMixin(MixinProtocol):
         collaboration: bool | None = None,
         moveItem: str | tuple[str, str] | None = None,
         addPlaylistId: str | None = None,
+        sortOrder: PlaylistSortOrder | None = None,
         addToTop: bool | None = None,
     ) -> str | JsonDict:
         """
@@ -330,6 +332,7 @@ class PlaylistsMixin(MixinProtocol):
         :param moveItem: Optional. Move one item before another. Items are specified by setVideoId, which is the
             unique id of this playlist item. See :py:func:`get_playlist`
         :param addPlaylistId: Optional. Id of another playlist to add to this playlist
+        :param sortOrder: Optional. Change the order tracks are returned in. The default is ``MANUAL``.
         :param addToTop: Optional. Change the state of this playlist to add items to the top of the playlist (if True)
             or the bottom of the playlist (if False - this is also the default of a new playlist).
         :return: Status String, ``collaboration`` dict described below, or full response
@@ -369,6 +372,11 @@ class PlaylistsMixin(MixinProtocol):
 
         if addPlaylistId:
             actions.append({"action": "ACTION_ADD_PLAYLIST", "addedFullListId": addPlaylistId})
+
+        if sortOrder:
+            actions.append(
+                {"action": "ACTION_SET_PLAYLIST_VIDEO_ORDER", "playlistVideoOrder": sortOrder.value}
+            )
 
         if addToTop:
             actions.append({"action": "ACTION_SET_ADD_TO_TOP", "addToTop": "true"})

--- a/ytmusicapi/models/content/enums.py
+++ b/ytmusicapi/models/content/enums.py
@@ -23,3 +23,10 @@ class VideoType(str, Enum):
     UGC = "MUSIC_VIDEO_TYPE_UGC"
     ATV = "MUSIC_VIDEO_TYPE_ATV"
     OFFICIAL_SOURCE_MUSIC = "MUSIC_VIDEO_TYPE_OFFICIAL_SOURCE_MUSIC"
+
+
+class PlaylistSortOrder(Enum):
+    MANUAL = 0
+    NEWEST_FIRST = 1
+    NEWEST_LAST = 2
+    TOP_VOTED = 6


### PR DESCRIPTION
For requests with voting access to playlists sorted by vote score,
`tracks` are no longer limited to the first 100.

Fixes #858