### PR TITLE
fix: album year parsing in `.get_artist` (#899)

### DIFF
--- a/tests/mixins/test_browsing.py
+++ b/tests/mixins/test_browsing.py
@@ -43,6 +43,12 @@ class TestBrowsing:
             [x for x in related if set(x.keys()) == {"browseId", "subscribers", "title", "thumbnails"}]
         ) == len(related)
 
+        # test that album type and year are being parsed correctly #899
+        assert all(album["year"].isnumeric() for album in results["albums"]["results"])
+        assert all(not album["type"].isnumeric() for album in results["albums"]["results"] if "type" in album)
+        assert all(single["year"].isnumeric() for single in results["singles"]["results"])
+        assert all(not single["type"].isnumeric() for single in results["singles"]["results"])
+
         results = yt.get_artist("UCLZ7tlKC06ResyDmEStSrOw")  # no album year
         assert len(results) >= 11
 

--- a/ytmusicapi/mixins/browsing.py
+++ b/ytmusicapi/mixins/browsing.py
@@ -209,6 +209,7 @@ class BrowsingMixin(MixinProtocol):
                         {
                             "title": "Stand By Me (Mustique Demo)",
                             "thumbnails": [...],
+                            "type": "Single",
                             "year": "2016",
                             "browseId": "MPREb_7MPKLhibN5G"
                         }

--- a/ytmusicapi/parsers/browsing.py
+++ b/ytmusicapi/parsers/browsing.py
@@ -62,10 +62,20 @@ def parse_content_list(results: JsonList, parse_func: ParseFuncDictType, key: st
     return contents
 
 
+def _parse_album_single_subtitle(result: JsonDict, album_or_single: JsonDict) -> JsonDict:
+    if type_or_year := nav(result, SUBTITLE, True):
+        if type_or_year.isnumeric():
+            album_or_single["year"] = type_or_year
+        else:
+            album_or_single["type"] = type_or_year
+            if (year := nav(result, SUBTITLE2, True)) and year.isnumeric():
+                album_or_single["year"] = year
+    return album_or_single
+
+
 def parse_album(result: JsonDict) -> JsonDict:
     album = {
         "title": nav(result, TITLE_TEXT),
-        "type": nav(result, SUBTITLE, True),
         "artists": [
             parse_id_name(x)
             for x in (nav(result, ["subtitle", "runs"], True) or [])
@@ -77,19 +87,17 @@ def parse_album(result: JsonDict) -> JsonDict:
         "isExplicit": nav(result, SUBTITLE_BADGE_LABEL, True) is not None,
     }
 
-    if (year := nav(result, SUBTITLE2, True)) and year.isnumeric():
-        album["year"] = year
-
-    return album
+    return _parse_album_single_subtitle(result, album)
 
 
 def parse_single(result: JsonDict) -> JsonDict:
-    return {
+    single = {
         "title": nav(result, TITLE_TEXT),
-        "year": nav(result, SUBTITLE, True),
         "browseId": nav(result, TITLE + NAVIGATION_BROWSE_ID),
         "thumbnails": nav(result, THUMBNAIL_RENDERER),
     }
+
+    return _parse_album_single_subtitle(result, single)
 
 
 def parse_song(result: JsonDict) -> JsonDict:


### PR DESCRIPTION
Mid 2025 YouTube switched the subtitles of albums and singles on an artist page around. Now albums just have a year and singles got merged with eps and therefore have type and year.

This PR changes the subtitle parsing so the first entry is treated as the year if it is numeric and otherwise as the type. If a second entry exists and it is numeric it is treated as the year.

Resolves #899 