### PR TITLE
Fixing branch name in readme links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Usage
     search_results = yt.search('Oasis Wonderwall')
     yt.add_playlist_items(playlistId, [search_results[0]['videoId']])
 
-The `tests <https://github.com/sigma67/ytmusicapi/blob/master/tests/>`_ are also a great source of usage examples.
+The `tests <https://github.com/sigma67/ytmusicapi/blob/main/tests/>`_ are also a great source of usage examples.
 
 .. end-features
 
@@ -111,4 +111,4 @@ Contributing
 ------------
 
 Pull requests are welcome. There are still some features that are not yet implemented.
-Please, refer to `CONTRIBUTING.rst <https://github.com/sigma67/ytmusicapi/blob/master/CONTRIBUTING.rst>`_ for guidance.
+Please, refer to `CONTRIBUTING.rst <https://github.com/sigma67/ytmusicapi/blob/main/CONTRIBUTING.rst>`_ for guidance.


### PR DESCRIPTION
"master" was used, branch is actually main, causing broken links