### PR TITLE
docs(README): add Related projects section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,18 @@ The `tests <https://github.com/sigma67/ytmusicapi/blob/master/tests/>`_ are also
 
 .. end-features
 
+Related projects
+----------------
+
+Tools and libraries that build on ytmusicapi:
+
+* `ytm-cli <https://github.com/chadfurman/ytm-cli>`_ — macOS terminal client
+  for YouTube Music. Uses ytmusicapi for history, library, playlists, search,
+  and playlist editing; drives the live YT Music tab in Google Chrome via
+  AppleScript for playback.
+
+If your project uses ytmusicapi and you'd like it listed, please open a PR.
+
 Contributing
 ------------
 


### PR DESCRIPTION
Adds a small **Related projects** section to the README, between the features block and the Contributing section.

Opens with one entry — [ytm-cli](https://github.com/chadfurman/ytm-cli), a macOS terminal client built on ytmusicapi — and ends with a one-liner inviting other downstream projects to PR themselves in. The intent is to give users a quick way to discover community tooling without you (or the user) having to dig.

Totally happy to:
- close this and move the list to a wiki page or pinned discussion if you'd rather not curate it on the README,
- drop the inviting line if you'd prefer a hand-curated list,
- adjust the wording / placement, or
- add this only as a docs page under `docs/` instead.

Diff is intentionally tiny — 12 lines, README only. Thanks for the library, it's been a joy to build against. ✌️