### PR TITLE
fix - search parse logic does not detect number of videos correctly

### DIFF
--- a/tests/mixins/test_search.py
+++ b/tests/mixins/test_search.py
@@ -113,6 +113,13 @@ class TestSearch:
         assert len(results) >= 3
         assert all(item["resultType"] == "episode" for item in results)
 
+    def test_search_playlist_return_correct_item_count(self, yt: YTMusic):
+        results = yt.search(query="Best Phonk music", filter="community_playlists")
+        assert all(item["itemCount"] is None for item in results)
+
+        results = yt.search(query="Best Phonk music", filter="featured_playlists")
+        assert all((item["itemCount"] is not None and isinstance(item["itemCount"], int)) for item in results)
+
     def test_search_episode_category(self, yt_auth):
         """Test resultType detection for episodes by searching for a podcast without a filter.
         Note 2025/10/20: categories are currently gone from default search, therefore category changed to None

--- a/ytmusicapi/mixins/search.py
+++ b/ytmusicapi/mixins/search.py
@@ -1,16 +1,33 @@
+from typing import Literal
+
 from ytmusicapi.continuations import get_continuations
 from ytmusicapi.exceptions import YTMusicUserError
 from ytmusicapi.mixins._protocol import MixinProtocol
 from ytmusicapi.parsers.search import *
 from ytmusicapi.type_alias import JsonList, ParseFuncType, RequestFuncType
 
+_SearchFilterType = (
+    Literal["songs"]
+    | Literal["videos"]
+    | Literal["albums"]
+    | Literal["artists"]
+    | Literal["playlists"]
+    | Literal["community_playlists"]
+    | Literal["featured_playlists"]
+    | Literal["profiles"]
+    | Literal["podcasts"]
+    | Literal["episodes"]
+)
+
+_SearchScopeType = Literal["uploads"] | Literal["library"]
+
 
 class SearchMixin(MixinProtocol):
     def search(
         self,
         query: str,
-        filter: str | None = None,
-        scope: str | None = None,
+        filter: _SearchFilterType | None = None,
+        scope: _SearchScopeType | None = None,
         limit: int = 20,
         ignore_spelling: bool = False,
     ) -> JsonList:
@@ -19,7 +36,7 @@ class SearchMixin(MixinProtocol):
         Returns results within the provided category.
 
         :param query: Query string, i.e. 'Oasis Wonderwall'
-        :param filter: Filter for item types. Allowed values: ``songs``, ``videos``, ``albums``, ``artists``, ``playlists``, ``community_playlists``, ``featured_playlists``, ``uploads``.
+        :param filter: Filter for item types. Allowed values: ``songs``, ``videos``, ``albums``, ``artists``, ``playlists``, ``community_playlists``, ``featured_playlists``, ``profiles``, ``podcasts``, ``episodes``.
           Default: Default search, including all types of items.
         :param scope: Search scope. Allowed values: ``library``, ``uploads``.
             Default: Search the public YouTube Music catalogue.
@@ -104,7 +121,9 @@ class SearchMixin(MixinProtocol):
                 "title": "Wonderwall - Oasis",
                 "author": "Tate Henderson",
                 "itemCount": "174"
-              },
+              }
+            itemCount of a playlist can be None as youtube music does not expose that information for search filtered to community playlist.
+              ,
               {
                 "category": "Videos",
                 "resultType": "video",
@@ -137,7 +156,6 @@ class SearchMixin(MixinProtocol):
                 "thumbnails": ...
               }
             ]
-
 
         """
         body = {"query": query}
@@ -206,11 +224,12 @@ class SearchMixin(MixinProtocol):
             return search_results
 
         # set filter for parser
+        internal_filter: str | None = None
         result_type = None
         if filter and "playlists" in filter:
-            filter = "playlists"
+            internal_filter = "playlists"
         elif scope == scopes[1]:  # uploads
-            filter = scopes[1]
+            internal_filter = scopes[1]
             result_type = scopes[1][:-1]
 
         for res in section_list:
@@ -234,15 +253,15 @@ class SearchMixin(MixinProtocol):
                 # if we know the filter it's easy to set the result type
                 # unfortunately uploads is modeled as a filter (historical reasons),
                 #  so we take care to not set the result type for that scope
-                if filter and not scope == scopes[1]:
-                    result_type = filter[:-1].lower()
+                if internal_filter and not scope == scopes[1]:
+                    result_type = internal_filter[:-1].lower()
 
             else:
                 continue
 
             search_results.extend(parse_search_results(shelf_contents, result_type, category))
 
-            if filter:  # if filter is set, there are continuations
+            if internal_filter:  # if filter is set, there are continuations
                 request_func: RequestFuncType = lambda additionalParams: self._send_request(
                     endpoint, body, additionalParams
                 )

--- a/ytmusicapi/mixins/search.py
+++ b/ytmusicapi/mixins/search.py
@@ -224,9 +224,9 @@ class SearchMixin(MixinProtocol):
             return search_results
 
         # set filter for parser
-        internal_filter: str | None = None
+        internal_filter: str | None = filter
         result_type = None
-        if filter and "playlists" in filter:
+        if internal_filter and "playlists" in internal_filter:
             internal_filter = "playlists"
         elif scope == scopes[1]:  # uploads
             internal_filter = scopes[1]

--- a/ytmusicapi/parsers/search.py
+++ b/ytmusicapi/parsers/search.py
@@ -128,7 +128,11 @@ def parse_search_result(data: JsonDict, result_type: str | None, category: str |
     elif result_type == "playlist":
         flex_item = nav(get_flex_column_item(data, 1), TEXT_RUNS)
         has_author = len(flex_item) == default_offset + 3
-        search_result["itemCount"] = (get_item_text(data, 1, has_author * 2) or "").split(" ")[0]
+        item_info_text = (get_item_text(data, 1, has_author * 2) or "").split(" ")
+
+        search_result["itemCount"] = (
+            item_info_text[0] if len(item_info_text) >= 2 and item_info_text[1] == "songs" else None
+        )
         if search_result["itemCount"] and search_result["itemCount"].isnumeric():
             search_result["itemCount"] = to_int(search_result["itemCount"])
         search_result["author"] = None if not has_author else get_item_text(data, 1, default_offset)


### PR DESCRIPTION
Relevant issue: #874 
- Added some typing QoL to search method
- Fix parsing logic to detect whether a number is actually itemCount of a playlist or not.