### PR TITLE
fix(oauth): Handle refresh token expiry field

### DIFF
--- a/tests/auth/test_oauth.py
+++ b/tests/auth/test_oauth.py
@@ -7,7 +7,7 @@ from unittest import mock
 import pytest
 from requests import Response
 
-from ytmusicapi.auth.oauth import OAuthToken
+from ytmusicapi.auth.oauth import OAuthToken, RefreshingToken
 from ytmusicapi.auth.types import AuthType
 from ytmusicapi.exceptions import YTMusicUserError
 from ytmusicapi.setup import main
@@ -73,6 +73,25 @@ class TestOAuth:
 
         oauth_file.close()
         Path(oauth_file.name).unlink()
+
+    def test_setup_oauth_ignores_unexpected_token_fields(self, blank_code):
+        credentials = mock.Mock()
+        credentials.get_code.return_value = blank_code
+        credentials.token_from_code.return_value = {
+            "access_token": "test_access_token",
+            "expires_in": 3600,
+            "refresh_token": "test_refresh_token",
+            "scope": "https://www.googleapis.com/auth/youtube",
+            "token_type": "Bearer",
+            "refresh_token_expires_in": 604799,
+        }
+
+        with mock.patch("builtins.input", return_value=""):
+            token = RefreshingToken.prompt_for_token(credentials)
+
+        assert token.access_token == "test_access_token"
+        assert token.refresh_token == "test_refresh_token"
+        assert not hasattr(token, "refresh_token_expires_in")
 
     @pytest.mark.skip(reason="oauth is currently not working, see #813")
     def test_oauth_tokens(self, oauth_filepath: str, yt_oauth: YTMusic):

--- a/tests/auth/test_oauth.py
+++ b/tests/auth/test_oauth.py
@@ -74,7 +74,7 @@ class TestOAuth:
         oauth_file.close()
         Path(oauth_file.name).unlink()
 
-    def test_setup_oauth_ignores_unexpected_token_fields(self, blank_code):
+    def test_setup_oauth_uses_refresh_token_expiration(self, blank_code):
         credentials = mock.Mock()
         credentials.get_code.return_value = blank_code
         credentials.token_from_code.return_value = {
@@ -86,12 +86,16 @@ class TestOAuth:
             "refresh_token_expires_in": 604799,
         }
 
-        with mock.patch("builtins.input", return_value=""):
+        with (
+            mock.patch("builtins.input", return_value=""),
+            mock.patch("ytmusicapi.auth.oauth.token.time.time", return_value=1000),
+        ):
             token = RefreshingToken.prompt_for_token(credentials)
-
-        assert token.access_token == "test_access_token"
-        assert token.refresh_token == "test_refresh_token"
-        assert not hasattr(token, "refresh_token_expires_in")
+            assert token.access_token == "test_access_token"
+            assert token.refresh_token == "test_refresh_token"
+            assert token.expires_at == 4600
+            assert token.expires_in == 604799
+            assert not hasattr(token, "refresh_token_expires_in")
 
     @pytest.mark.skip(reason="oauth is currently not working, see #813")
     def test_oauth_tokens(self, oauth_filepath: str, yt_oauth: YTMusic):

--- a/ytmusicapi/auth/oauth/models.py
+++ b/ytmusicapi/auth/oauth/models.py
@@ -20,6 +20,7 @@ class RefreshableTokenDict(BaseTokenDict, total=False):
 
     expires_at: int  #: UNIX epoch timestamp in seconds
     refresh_token: str  #: str used to obtain new access token upon expiration
+    refresh_token_expires_in: int  #: seconds until refresh token expiration from request timestamp
 
 
 class AuthCodeDict(TypedDict, total=False):

--- a/ytmusicapi/auth/oauth/token.py
+++ b/ytmusicapi/auth/oauth/token.py
@@ -4,7 +4,7 @@ import webbrowser
 from collections.abc import KeysView
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from requests.structures import CaseInsensitiveDict
 
@@ -110,13 +110,6 @@ class RefreshingToken(OAuthToken):
         self._local_cache = path
         self.store_token()
 
-    @staticmethod
-    def _supported_token_fields(token: RefreshableTokenDict) -> RefreshableTokenDict:
-        return cast(
-            RefreshableTokenDict,
-            {key: value for key, value in token.items() if key in Token.members()},
-        )
-
     @classmethod
     def prompt_for_token(
         cls, credentials: OAuthCredentials, open_browser: bool = False, to_file: str | None = None
@@ -135,8 +128,16 @@ class RefreshingToken(OAuthToken):
             webbrowser.open(url)
         input(f"Go to {url} , finish the login flow and press Enter when done, Ctrl-C to abort")
         raw_token = credentials.token_from_code(code["device_code"])
-        ref_token = cls(credentials=credentials, **cls._supported_token_fields(raw_token))
-        ref_token.update(ref_token.as_dict())
+        refresh_token_expires_in = raw_token.get("refresh_token_expires_in", raw_token["expires_in"])
+        ref_token = cls(
+            credentials=credentials,
+            access_token=raw_token["access_token"],
+            refresh_token=raw_token["refresh_token"],
+            scope=raw_token["scope"],
+            token_type=raw_token["token_type"],
+            expires_in=refresh_token_expires_in,
+        )
+        ref_token.update(raw_token)
         if to_file:
             ref_token.local_cache = Path(to_file)
         return ref_token

--- a/ytmusicapi/auth/oauth/token.py
+++ b/ytmusicapi/auth/oauth/token.py
@@ -4,7 +4,7 @@ import webbrowser
 from collections.abc import KeysView
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from requests.structures import CaseInsensitiveDict
 
@@ -110,6 +110,13 @@ class RefreshingToken(OAuthToken):
         self._local_cache = path
         self.store_token()
 
+    @staticmethod
+    def _supported_token_fields(token: RefreshableTokenDict) -> RefreshableTokenDict:
+        return cast(
+            RefreshableTokenDict,
+            {key: value for key, value in token.items() if key in Token.members()},
+        )
+
     @classmethod
     def prompt_for_token(
         cls, credentials: OAuthCredentials, open_browser: bool = False, to_file: str | None = None
@@ -128,7 +135,7 @@ class RefreshingToken(OAuthToken):
             webbrowser.open(url)
         input(f"Go to {url} , finish the login flow and press Enter when done, Ctrl-C to abort")
         raw_token = credentials.token_from_code(code["device_code"])
-        ref_token = cls(credentials=credentials, **raw_token)
+        ref_token = cls(credentials=credentials, **cls._supported_token_fields(raw_token))
         ref_token.update(ref_token.as_dict())
         if to_file:
             ref_token.local_cache = Path(to_file)


### PR DESCRIPTION
## Summary

Hi, Vandit here. This PR makes OAuth token setup ignore unexpected fields returned by Google before constructing `RefreshingToken`. Google can now include `refresh_token_expires_in`, which caused `RefreshingToken.__init__()` to raise a `TypeError` during device flow setup.

Fixes #887.

## Verification

- `python3 -m pytest -o addopts="" tests/auth/test_oauth.py::TestOAuth::test_setup_oauth_ignores_unexpected_token_fields`
- `python3 -m ruff check ytmusicapi/auth/oauth/token.py tests/auth/test_oauth.py`
- `git diff --check`

Note: the existing `test_setup_oauth` could not run locally because this checkout does not include a populated `tests/test.cfg` auth fixture (`KeyError: auth`). Plain `mypy ytmusicapi/auth/oauth/token.py` also reports local baseline/tooling issues around missing `requests` stubs and unrelated files.