### PR TITLE
fix(oauth): tolerate unexpected token fields when loading saved oauth.json

### DIFF
--- a/tests/auth/test_oauth.py
+++ b/tests/auth/test_oauth.py
@@ -97,6 +97,30 @@ class TestOAuth:
             assert token.expires_in == 604799
             assert not hasattr(token, "refresh_token_expires_in")
 
+    def test_oauth_token_dict_ignores_unexpected_fields(self):
+        """Regression for #887 / #921: a saved oauth.json may contain extra
+        fields like ``refresh_token_expires_in`` (added to Google's device-flow
+        response). Loading such a token via ``YTMusic`` must not crash on the
+        strict Token dataclass.
+        """
+        credentials = mock.Mock(spec=OAuthCredentials)
+        token_dict = {
+            "scope": "https://www.googleapis.com/auth/youtube",
+            "token_type": "Bearer",
+            "access_token": "test_access_token",
+            "refresh_token": "test_refresh_token",
+            "expires_at": int(time.time()) + 3600,
+            "expires_in": 3600,
+            "refresh_token_expires_in": 604799,
+        }
+
+        yt = YTMusic(token_dict, oauth_credentials=credentials)
+
+        assert yt.auth_type == AuthType.OAUTH_CUSTOM_CLIENT
+        assert yt._token is not None
+        assert yt._token.refresh_token == "test_refresh_token"
+        assert not hasattr(yt._token, "refresh_token_expires_in")
+
     @pytest.mark.skip(reason="oauth is currently not working, see #813")
     def test_oauth_tokens(self, oauth_filepath: str, yt_oauth: YTMusic):
         # ensure instance initialized token

--- a/ytmusicapi/ytmusic.py
+++ b/ytmusicapi/ytmusic.py
@@ -110,11 +110,14 @@ class YTMusicBase:
                         "oauth JSON provided via auth argument, but oauth_credentials not provided."
                         "Please provide oauth_credentials as specified in the OAuth setup documentation."
                     )
+                # Filter unknown keys (e.g. ``refresh_token_expires_in`` from Google's
+                # device flow) so previously saved oauth.json files load cleanly. See #921.
+                token_kwargs = {k: self._auth_headers[k] for k in Token.members() if k in self._auth_headers}
                 #: OAuth credential handler
                 self._token = RefreshingToken(
                     credentials=oauth_credentials,
                     _local_cache=auth_path,
-                    **self._auth_headers,  # type: ignore[arg-type]
+                    **token_kwargs,  # type: ignore[arg-type]
                 )
 
         # prepare context


### PR DESCRIPTION
## Summary

Saved OAuth token files (or hand-edited `oauth.json` files) may contain fields the strict `Token` dataclass does not accept — notably `refresh_token_expires_in`, which Google now returns in the device-flow response. #927 fixed this for `prompt_for_token` when the device flow first runs, but `YTMusic.__init__` still splats the entire saved auth dict into `RefreshingToken(...)`, so the same `TypeError` reappears every time such a file is loaded.

Fixes #921 (complements #887 / #927).

## Fix

`YTMusic.__init__` filters `_auth_headers` to `Token.members()` before unpacking into `RefreshingToken(...)`. Mirrors #927's approach in `prompt_for_token`. Forward-compatible: any future field Google adds is silently dropped instead of crashing.

## Verification

- New test `test_oauth_token_dict_ignores_unexpected_fields` covers loading a token dict containing `refresh_token_expires_in`. Verified it fails on `main` with the exact `TypeError` from #921, and passes with the patch.
- `ruff check`, `ruff format --check`, and `mypy --strict` all pass on the changed files.