### PR TITLE
fix: adapt tests and parsing to YT server changes

### DIFF
--- a/tests/mixins/test_playlists.py
+++ b/tests/mixins/test_playlists.py
@@ -195,7 +195,7 @@ class TestPlaylists:
 
     def test_edit_playlist_collaboration(self, yt_oauth, yt_brand):
         playlist_id = yt_oauth.create_playlist("test collaboration", "", privacy_status="UNLISTED")
-        assert len(playlist_id) == 34, "Playlist creation failed"
+        assert isinstance(playlist_id, str) and playlist_id.startswith("PL"), "Playlist creation failed"
 
         try:
             response = yt_oauth.edit_playlist(
@@ -234,8 +234,7 @@ class TestPlaylists:
 
     def test_edit_playlist_community_vote(self, yt_oauth: YTMusic):
         playlist_id = yt_oauth.create_playlist("test edit community vote", "", privacy_status="UNLISTED")
-        assert len(playlist_id) == 34, "Playlist creation failed"
-        assert isinstance(playlist_id, str), "Playlist creation failed"
+        assert isinstance(playlist_id, str) and playlist_id.startswith("PL"), "Playlist creation failed"
 
         try:
             response = yt_oauth.edit_playlist(playlist_id, collaboration=True)
@@ -269,7 +268,7 @@ class TestPlaylists:
             "test description",
             source_playlist="OLAK5uy_lGQfnMNGvYCRdDq9ZLzJV2BJL2aHQsz9Y",
         )
-        assert len(playlist_id) == 34, "Playlist creation failed"
+        assert isinstance(playlist_id, str) and playlist_id.startswith("PL"), "Playlist creation failed"
         yt_brand.edit_playlist(playlist_id, addToTop=True)
         response = yt_brand.add_playlist_items(
             playlist_id,

--- a/tests/mixins/test_search.py
+++ b/tests/mixins/test_search.py
@@ -134,7 +134,7 @@ class TestSearch:
         assert episode["podcast"]["id"] == "MPSPPLxq_lXOUlvQDUNyoBYLkN8aVt5yAwEtG9"
 
     def test_search_top_result_playlist(self, yt_oauth):
-        results = yt_oauth.search("grace ost complete playlist")  # issue 524
+        results = yt_oauth.search('intitle:"grace OST" playlist')  # issue 524
         assert results[0]["category"] == "Top result"
         assert results[0]["resultType"] == "playlist"
         assert results[0]["playlistId"].startswith("PL")

--- a/tests/parsers/test_songs.py
+++ b/tests/parsers/test_songs.py
@@ -1,0 +1,29 @@
+from ytmusicapi.parsers.constants import DOT_SEPARATOR_RUN
+from ytmusicapi.parsers.songs import parse_song_runs
+
+DOT = DOT_SEPARATOR_RUN
+
+
+def _linked(name: str, browse_id: str) -> dict:
+    return {"text": name, "navigationEndpoint": {"browseEndpoint": {"browseId": browse_id}}}
+
+
+class TestParseSongRuns:
+    def test_skip_type_spec_before_artist(self):
+        runs = [{"text": "Song"}, DOT, _linked("Eminem", "UCedvOgsKFzcK3hA5taf3KoQ"), DOT, {"text": "2:16"}]
+        parsed = parse_song_runs(runs, skip_type_spec=True)
+        assert parsed["artists"] == [{"name": "Eminem", "id": "UCedvOgsKFzcK3hA5taf3KoQ"}]
+
+    def test_skip_type_spec_when_song_has_no_artist(self):
+        # artist-less song: "Song • 2:16 • 5.4K plays" must not leak "Song" as an artist
+        runs = [{"text": "Song"}, DOT, {"text": "2:16"}, {"text": ""}, {"text": "5.4K plays"}]
+        parsed = parse_song_runs(runs, skip_type_spec=True)
+        assert "artists" not in parsed
+        assert parsed["duration"] == "2:16"
+        assert parsed["views"] == "5.4K"
+
+    def test_linked_leading_artist_is_not_stripped(self):
+        # no type spec: a linked artist in the first run must survive
+        runs = [_linked("Eminem", "UCedvOgsKFzcK3hA5taf3KoQ"), DOT, {"text": "2:16"}]
+        parsed = parse_song_runs(runs, skip_type_spec=True)
+        assert parsed["artists"] == [{"name": "Eminem", "id": "UCedvOgsKFzcK3hA5taf3KoQ"}]

--- a/ytmusicapi/navigation.py
+++ b/ytmusicapi/navigation.py
@@ -90,6 +90,7 @@ CAROUSEL = ["musicCarouselShelfRenderer"]
 IMMERSIVE_CAROUSEL = ["musicImmersiveCarouselShelfRenderer"]
 CAROUSEL_CONTENTS = [*CAROUSEL, "contents"]
 CAROUSEL_TITLE = [*HEADER, "musicCarouselShelfBasicHeaderRenderer", *TITLE]
+CAROUSEL_STRAPLINE = [*HEADER, "musicCarouselShelfBasicHeaderRenderer", "strapline", "runs", 0]
 CARD_SHELF_TITLE = [*HEADER, "musicCardShelfHeaderBasicRenderer", *TITLE_TEXT]
 FRAMEWORK_MUTATIONS = ["frameworkUpdates", "entityBatchUpdate", "mutations"]
 TIMESTAMPED_LYRICS = [

--- a/ytmusicapi/parsers/browsing.py
+++ b/ytmusicapi/parsers/browsing.py
@@ -21,7 +21,10 @@ def parse_mixed_content(
             results = next(iter(row.values()))
             if "contents" not in results:
                 continue
-            title = nav(results, [*CAROUSEL_TITLE, "text"])
+            # some carousel headers only carry a strapline (e.g. "MORE FROM") instead of a title
+            title = nav(results, [*CAROUSEL_TITLE, "text"], True) or nav(
+                results, [*CAROUSEL_STRAPLINE, "text"], True
+            )
             contents = []
             for result in results["contents"]:
                 data = nav(result, [MTRIR], True)

--- a/ytmusicapi/parsers/songs.py
+++ b/ytmusicapi/parsers/songs.py
@@ -50,13 +50,15 @@ def parse_song_runs(runs: JsonList, skip_type_spec: bool = False) -> JsonDict:
     parsed: JsonDict = {}
 
     # prevent type specifier from being parsed as an artist
-    # it's the first run, separated from the actual artists by " • "
+    # it's the unlinked first run, separated by " • " from the artists, or from
+    # metadata (duration/views/year) when the song lists no artist at all
     if (
         skip_type_spec
         and len(runs) > 2
+        and "navigationEndpoint" not in runs[0]
         and parse_song_run(runs[0])["type"] == "artist"
         and runs[1] == DOT_SEPARATOR_RUN
-        and parse_song_run(runs[2])["type"] == "artist"
+        and parse_song_run(runs[2])["type"] in ("artist", "duration", "views", "year")
     ):
         runs = runs[2:]
 


### PR DESCRIPTION
Investigating the flaky CI in #959 surfaced a mix of test-only staleness and two genuine parser bugs newly exposed by YouTube server-side changes. None are related to #959's own changes.

## Parser fixes (real bugs)

- **Type specifier leaked as artist for artist-less songs.** A song search result with no listed artist renders as `Song • 2:16 • 5.4K plays`. `parse_song_runs`' `skip_type_spec` guard only stripped the `Song` prefix when an artist followed it, so the type label leaked as a fake artist `{"name": "Song", "id": None}` — which is what `test_search_queries` was (correctly) catching. Now the (always unlinked) type specifier is also stripped when followed by metadata (duration/views/year), while a linked leading artist is never stripped. `test_search_queries` keeps its original strict assertion. Added network-free unit tests (`tests/parsers/test_songs.py`).
- **Carousel headers with only a `strapline`.** Some carousels (e.g. "MORE FROM" in `get_song_related`) now carry a `strapline` instead of a `title`, making `parse_mixed_content` raise `KeyError`. It now falls back to the strapline text.

## Test updates (server-side changes)

- `create_playlist` now returns short ids (e.g. `PLMC-vWU9tmrc`, 13 chars); the three `test_edit_playlist_*`/`test_end2end` assertions now check the result is a `str` starting with `PL` instead of a fixed length of 34. The root cause is that YT changed the ID-generation scheme for newly created playlists to a shorter suffix — 11 characters → PL + 11 = 13 total
- `test_search_top_result_playlist`: query changed to `intitle:"grace OST" playlist`, which reliably returns a playlist top result.

## Verification

Run against a live account locally:
- `test_search.py` full module: 21/21 pass; `test_search_queries` (all 6 params) green across 3 consecutive runs with the strict assertion.
- `test_get_song_related_content` and `test_search_top_result_playlist` pass.
- `tests/parsers/test_songs.py`: 3/3 (the artist-less case fails on the pre-fix parser).
- `ruff` and `mypy` clean.

## Known remaining item

`test_edit_playlist_community_vote` has a separate **transient 409** on the `edit_playlist(collaboration=True)` call issued immediately after `create_playlist` — the new short-id playlists appear to be provisioned asynchronously, so an edit milliseconds later sometimes races. This is intermittent and independent of the assertion fix. Not addressed here pending a decision on retry vs. wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)