### PR TITLE
fix(ci): grant write permissions to dependency update job

### DIFF
--- a/.github/workflows/pdm.yml
+++ b/.github/workflows/pdm.yml
@@ -4,12 +4,15 @@ on:
   schedule:
     - cron: "5 3 1 * *"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   update-dependencies:
     runs-on: ubuntu-latest
+    permissions:
+      # update-deps-action runs create-pull-request internally, which pushes a branch and opens the PR
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## Problem

The monthly `Update dependencies` workflow has failed since June:

- [Run 28500493031](https://github.com/sigma67/ytmusicapi/actions/runs/28500493031) (Jul 1) — `Error creating blob for file 'pdm.lock': Resource not accessible by integration`
- [Run 26744406650](https://github.com/sigma67/ytmusicapi/actions/runs/26744406650) (Jun 1) — same error

## Cause

`e3c32f7` (#925) added a workflow-level `permissions: contents: read` block to `pdm.yml`. `pdm-project/update-deps-action` runs `peter-evans/create-pull-request` internally, which needs write access to create the blob/branch and open the PR. The last run before that commit (May 1) succeeded; every run after it failed.

## Fix

Keep the workflow default at no permissions (`permissions: {}`) and grant the narrower set at the job level, matching the pattern already used in `coverage.yml`:

- `contents: write` — push the update branch
- `pull-requests: write` — open the PR

## Notes

- Requires *Settings → Actions → Allow GitHub Actions to create and approve pull requests* to be enabled. It was working before May 4, so this should already be the case.
- The workflow is `schedule`-only, so this can't be verified before the next cron fire (Aug 1). Happy to add a `workflow_dispatch` trigger if you'd like to test it manually.
- The Node.js 20 deprecation warnings in those runs come from action versions pinned inside `update-deps-action@main` and are unrelated to the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)