### PR TITLE
test: remove temporary xdist flags from addopts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,7 @@ include-package-data = false
 [tool.pytest.ini_options]
 python_functions = "test_*"
 testpaths = ["tests"]
-# TEMP: -n/--dist belong in coverage.yml, but pull_request_target takes the workflow
-# from the base ref, so they have to live here to be measurable before merge.
-addopts = "--verbose --cov --junitxml=junit.xml --retries 0 --retry-delay 5 --durations=0 -n 2 --dist loadgroup"
+addopts = "--verbose --cov --junitxml=junit.xml --retries 0 --retry-delay 5 --durations=0"
 
 [tool.coverage.run]
 source = ["ytmusicapi"]


### PR DESCRIPTION
Follow-up to #966, removing the temporary commit that shipped with it.

`-n 2 --dist loadgroup` was put into `pyproject.toml`'s `addopts` only so the parallel run could be measured before #966 merged: `pull_request_target` takes the workflow definition from the base ref, so the same flags added to `coverage.yml` had no effect on that PR's own CI.

Now that `coverage.yml` is on main and carries the flags, the duplication can go.

- CI is unaffected — `coverage.yml` still runs `pdm run pytest -n 2 --dist loadgroup --junitxml=test-results.xml`.
- `pdm run pytest` goes back to running serially, which keeps per-test output readable and avoids two contributors putting four concurrent clients on the shared test account.
- Parallel stays opt-in locally: `pdm run pytest -n 2 --dist loadgroup`.

Verified both: collection reports no workers by default, and `-n 2 --dist loadgroup` still spins up `2/2 workers` and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
