### PR TITLE
chore: bump pinned action SHAs to latest versions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout repository
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
         persist-credentials: false
@@ -41,7 +41,7 @@ jobs:
       with:
         python-version: "3.10"
     - name: Setup PDM
-      uses: pdm-project/setup-pdm@94a823180e06fcde4ad29308721954a521c96ed0  # v4.4
+      uses: pdm-project/setup-pdm@973541a5febeafcfdadf8a51211435be6ecfd90f  # v4.5
     - name: Write OAuth credentials
       env:
         OAUTH_JSON: ${{ secrets.OAUTH_JSON }}


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v7.0.0 to v7.0.1 in coverage.yml
- Bump `pdm-project/setup-pdm` from v4.4 to v4.5 in coverage.yml

Other actions across workflows were already at their latest release (or track a floating tag/branch that auto-updates), so no further changes were needed.

## Test plan
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)