### PR TITLE
fix: skip unexpected renderer types in parse_content_list

### DIFF
--- a/tests/parsers/test_browsing.py
+++ b/tests/parsers/test_browsing.py
@@ -1,6 +1,7 @@
 import pytest
 
-from ytmusicapi.parsers.browsing import parse_playlist
+from ytmusicapi.navigation import MRLIR, MTRIR
+from ytmusicapi.parsers.browsing import parse_content_list, parse_playlist
 
 
 def _playlist_item(thumbnail_renderer: dict) -> dict:
@@ -47,3 +48,16 @@ class TestParsePlaylist:
         parsed = parse_playlist(_playlist_item(thumbnail_renderer))
         assert parsed["playlistId"] == "PLabc123"
         assert parsed["thumbnails"] is None
+
+
+class TestParseContentList:
+    def test_mixed_renderers_are_skipped(self):
+        """A mood/genre carousel can mix renderer types; only the requested key is parsed."""
+        results = [
+            {MTRIR: {"id": 1}},
+            {MRLIR: {"id": 2}},
+            {MTRIR: {"id": 3}},
+        ]
+
+        assert parse_content_list(results, lambda item: item["id"], MTRIR) == [1, 3]
+        assert parse_content_list(results, lambda item: item["id"], MRLIR) == [2]

--- a/ytmusicapi/parsers/browsing.py
+++ b/ytmusicapi/parsers/browsing.py
@@ -60,6 +60,11 @@ def parse_mixed_content(
 def parse_content_list(results: JsonList, parse_func: ParseFuncDictType, key: str = MTRIR) -> JsonList:
     contents = []
     for result in results:
+        # carousels can mix renderer types (e.g. songs/videos alongside playlists),
+        # so skip anything that isn't the renderer parse_func expects
+        if key not in result:
+            continue
+
         contents.append(parse_func(result[key]))
 
     return contents


### PR DESCRIPTION
Closes #949

`parse_content_list` indexed every carousel result with the requested renderer key unconditionally, so a "Moods & Genres" page whose carousel mixes content types (songs/videos alongside playlists) raised `KeyError: 'musicTwoRowItemRenderer'` in `get_mood_playlists`. Results that don't carry the requested key are now skipped, matching what the caller asked for.

Added `tests/parsers/test_browsing.py` covering a mixed `MTRIR`/`MRLIR` list; it fails with `KeyError` on current main and passes with the fix.
