### PR TITLE
Expose ownership for library playlists

### DIFF
--- a/tests/parsers/data.py
+++ b/tests/parsers/data.py
@@ -1,0 +1,33 @@
+OWNED_PLAYLIST = {
+    "thumbnailRenderer": {"musicThumbnailRenderer": {"thumbnail": {"thumbnails": []}}},
+    "title": {
+        "runs": [
+            {
+                "text": "Family playlist",
+                "navigationEndpoint": {"browseEndpoint": {"browseId": "VLPL_family"}},
+            }
+        ]
+    },
+    "subtitle": {
+        "runs": [
+            {
+                "text": "Owner",
+                "navigationEndpoint": {"browseEndpoint": {"browseId": "UC_owner"}},
+            },
+            {"text": " • "},
+            {"text": "1 track"},
+        ]
+    },
+    "menu": {
+        "menuRenderer": {
+            "items": [
+                {
+                    "menuNavigationItemRenderer": {
+                        "text": {"runs": [{"text": "Edit playlist"}]},
+                        "navigationEndpoint": {"playlistEditorEndpoint": {"playlistId": "PL_family"}},
+                    }
+                }
+            ]
+        }
+    },
+}

--- a/tests/parsers/test_browsing.py
+++ b/tests/parsers/test_browsing.py
@@ -2,41 +2,8 @@ from copy import deepcopy
 
 import pytest
 
+from tests.parsers.data import OWNED_PLAYLIST
 from ytmusicapi.parsers.browsing import parse_playlist
-
-OWNED_PLAYLIST = {
-    "thumbnailRenderer": {"musicThumbnailRenderer": {"thumbnail": {"thumbnails": []}}},
-    "title": {
-        "runs": [
-            {
-                "text": "Family playlist",
-                "navigationEndpoint": {"browseEndpoint": {"browseId": "VLPL_family"}},
-            }
-        ]
-    },
-    "subtitle": {
-        "runs": [
-            {
-                "text": "Owner",
-                "navigationEndpoint": {"browseEndpoint": {"browseId": "UC_owner"}},
-            },
-            {"text": " • "},
-            {"text": "1 track"},
-        ]
-    },
-    "menu": {
-        "menuRenderer": {
-            "items": [
-                {
-                    "menuNavigationItemRenderer": {
-                        "text": {"runs": [{"text": "Edit playlist"}]},
-                        "navigationEndpoint": {"playlistEditorEndpoint": {"playlistId": "PL_family"}},
-                    }
-                }
-            ]
-        }
-    },
-}
 
 
 def test_parse_playlist_marks_playlist_with_editor_endpoint_as_owned():

--- a/tests/parsers/test_browsing.py
+++ b/tests/parsers/test_browsing.py
@@ -45,7 +45,9 @@ def test_parse_playlist_marks_playlist_with_editor_endpoint_as_owned():
 
 def test_parse_playlist_marks_playlist_without_editor_endpoint_as_not_owned():
     saved_playlist = deepcopy(OWNED_PLAYLIST)
-    del saved_playlist["menu"]
+    saved_playlist["menu"]["menuRenderer"]["items"][0]["menuNavigationItemRenderer"]["navigationEndpoint"] = {
+        "watchPlaylistEndpoint": {"playlistId": "PL_family"}
+    }
 
     playlist = parse_playlist(saved_playlist)
 

--- a/tests/parsers/test_browsing.py
+++ b/tests/parsers/test_browsing.py
@@ -1,0 +1,52 @@
+from copy import deepcopy
+
+from ytmusicapi.parsers.browsing import parse_playlist
+
+OWNED_PLAYLIST = {
+    "thumbnailRenderer": {"musicThumbnailRenderer": {"thumbnail": {"thumbnails": []}}},
+    "title": {
+        "runs": [
+            {
+                "text": "Family playlist",
+                "navigationEndpoint": {"browseEndpoint": {"browseId": "VLPL_family"}},
+            }
+        ]
+    },
+    "subtitle": {
+        "runs": [
+            {
+                "text": "Owner",
+                "navigationEndpoint": {"browseEndpoint": {"browseId": "UC_owner"}},
+            },
+            {"text": " • "},
+            {"text": "1 track"},
+        ]
+    },
+    "menu": {
+        "menuRenderer": {
+            "items": [
+                {
+                    "menuNavigationItemRenderer": {
+                        "text": {"runs": [{"text": "Edit playlist"}]},
+                        "navigationEndpoint": {"playlistEditorEndpoint": {"playlistId": "PL_family"}},
+                    }
+                }
+            ]
+        }
+    },
+}
+
+
+def test_parse_playlist_marks_playlist_with_editor_endpoint_as_owned():
+    playlist = parse_playlist(OWNED_PLAYLIST)
+
+    assert playlist["owned"] is True
+
+
+def test_parse_playlist_marks_playlist_without_editor_endpoint_as_not_owned():
+    saved_playlist = deepcopy(OWNED_PLAYLIST)
+    del saved_playlist["menu"]
+
+    playlist = parse_playlist(saved_playlist)
+
+    assert playlist["owned"] is False

--- a/ytmusicapi/mixins/library.py
+++ b/ytmusicapi/mixins/library.py
@@ -31,7 +31,7 @@ class LibraryMixin(MixinProtocol):
                 'playlistId': 'PLQwVIlKxHM6rz0fDJVv_0UlXGEWf-bFys',
                 'title': 'Playlist title',
                 'thumbnails': [...],
-                'count': 5,
+                'count': '5',
                 'owned': True
             }
         """

--- a/ytmusicapi/mixins/library.py
+++ b/ytmusicapi/mixins/library.py
@@ -23,15 +23,16 @@ class LibraryMixin(MixinProtocol):
         Retrieves the playlists in the user's library.
 
         :param limit: Number of playlists to retrieve. ``None`` retrieves them all.
-        :return: List of owned playlists.
+        :return: List of playlists in the user's library.
 
         Each item is in the following format::
 
             {
                 'playlistId': 'PLQwVIlKxHM6rz0fDJVv_0UlXGEWf-bFys',
                 'title': 'Playlist title',
-                'thumbnails: [...],
-                'count': 5
+                'thumbnails': [...],
+                'count': 5,
+                'owned': True
             }
         """
         self._check_auth()

--- a/ytmusicapi/parsers/browsing.py
+++ b/ytmusicapi/parsers/browsing.py
@@ -160,14 +160,30 @@ def parse_video(result: JsonDict) -> JsonDict:
 
 
 def parse_playlist(data: JsonDict) -> JsonDict:
+    playlist_id = nav(data, TITLE + NAVIGATION_BROWSE_ID)[2:]
+    menu_items = nav(data, ["menu", "menuRenderer", "items"], True) or []
     playlist = {
         "title": nav(
             data,
             TITLE_TEXT,
             none_if_absent=True,  # rare but possible for playlist title to be missing
         ),
-        "playlistId": nav(data, TITLE + NAVIGATION_BROWSE_ID)[2:],
+        "playlistId": playlist_id,
         "thumbnails": nav(data, THUMBNAIL_RENDERER),
+        "owned": any(
+            nav(
+                item,
+                [
+                    "menuNavigationItemRenderer",
+                    "navigationEndpoint",
+                    "playlistEditorEndpoint",
+                    "playlistId",
+                ],
+                True,
+            )
+            == playlist_id
+            for item in menu_items
+        ),
     }
     subtitle = data["subtitle"]
     if "runs" in subtitle:


### PR DESCRIPTION
## Summary

- expose `owned` for playlists parsed from library/grid cards
- derive ownership from the language-independent `playlistEditorEndpoint`
- document the new return field and correct the library return description
- add parser tests for owned and saved playlists

## Why

`get_library_playlists()` currently drops the edit endpoint contained in the raw playlist card. Downstream clients therefore cannot distinguish an owned playlist from a saved playlist without issuing an extra detail request per item.

The new boolean is independent of playlist privacy: public, unlisted, and private playlists can all be editable when owned by the authenticated account.

Closes #971

## Downstream

This unblocks the owned-playlist editability fix in music-assistant/server#5187, which is waiting for this change to be merged and released.

## Tests

```text
pytest -o addopts='' tests/parsers -q
36 passed

pre-commit run --files ytmusicapi/parsers/browsing.py ytmusicapi/mixins/library.py tests/parsers/test_browsing.py
ruff: passed
ruff format: passed
mypy: passed
```

