### PR TITLE
fix(parsers): tolerate playlist headers without secondSubtitle

### DIFF
--- a/tests/parsers/test_playlists.py
+++ b/tests/parsers/test_playlists.py
@@ -1,0 +1,31 @@
+from ytmusicapi.parsers.playlists import parse_playlist_header_meta
+
+
+def _header(**extra: dict) -> dict:
+    header = {
+        "title": {"runs": [{"text": "My Playlist"}]},
+        "thumbnail": {
+            "musicThumbnailRenderer": {
+                "thumbnail": {"thumbnails": [{"url": "https://example.com/t.jpg", "width": 60, "height": 60}]}
+            }
+        },
+    }
+    header.update(extra)
+    return header
+
+
+class TestParsePlaylistHeaderMeta:
+    def test_missing_second_subtitle(self):
+        # some playlists are served without a secondSubtitle at all
+        parsed = parse_playlist_header_meta(_header())
+        assert parsed["title"] == "My Playlist"
+        assert parsed["views"] is None
+        assert parsed["duration"] is None
+        assert parsed["trackCount"] is None
+
+    def test_second_subtitle_track_count(self):
+        parsed = parse_playlist_header_meta(
+            _header(secondSubtitle={"runs": [{"text": "101 songs"}, {"text": " • "}, {"text": "6+ hours"}]})
+        )
+        assert parsed["trackCount"] == 101
+        assert parsed["duration"] == "6+ hours"

--- a/ytmusicapi/parsers/playlists.py
+++ b/ytmusicapi/parsers/playlists.py
@@ -75,7 +75,7 @@ def parse_playlist_header_meta(header: JsonDict) -> JsonDict:
                     True,
                 ),
             }
-    if "runs" in header["secondSubtitle"]:
+    if "runs" in header.get("secondSubtitle", {}):
         second_subtitle_runs = header["secondSubtitle"]["runs"]
         has_views = (len(second_subtitle_runs) > 3) * 2
         playlist_meta["views"] = None if not has_views else to_int(second_subtitle_runs[0]["text"])


### PR DESCRIPTION
Closes #892

`parse_playlist_header_meta` indexed `header["secondSubtitle"]` directly, so a playlist whose header omits that field raised `KeyError: 'secondSubtitle'` and `get_playlist` failed outright. The sibling `title` lookup in the same function already guards with `.get`, so this does the same — `views`/`duration`/`trackCount` just stay `None`.

New `tests/parsers/test_playlists.py` fails with the original `KeyError` and passes with the fix.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
