### PR TITLE
Tolerate missing thumbnails when parsing playlist items

### DIFF
--- a/tests/parsers/test_browsing.py
+++ b/tests/parsers/test_browsing.py
@@ -1,0 +1,49 @@
+import pytest
+
+from ytmusicapi.parsers.browsing import parse_playlist
+
+
+def _playlist_item(thumbnail_renderer: dict) -> dict:
+    return {
+        "title": {
+            "runs": [
+                {
+                    "text": "My playlist",
+                    "navigationEndpoint": {"browseEndpoint": {"browseId": "VLPLabc123"}},
+                }
+            ]
+        },
+        "subtitle": {"runs": [{"text": "Playlist"}]},
+        **thumbnail_renderer,
+    }
+
+
+THUMBNAIL_RENDERER = {
+    "thumbnailRenderer": {
+        "musicThumbnailRenderer": {
+            "thumbnail": {"thumbnails": [{"url": "https://example.com/t.jpg", "width": 1, "height": 1}]}
+        }
+    }
+}
+
+
+class TestParsePlaylist:
+    def test_thumbnails(self):
+        parsed = parse_playlist(_playlist_item(THUMBNAIL_RENDERER))
+        assert parsed["playlistId"] == "PLabc123"
+        assert parsed["thumbnails"] == [{"url": "https://example.com/t.jpg", "width": 1, "height": 1}]
+
+    @pytest.mark.parametrize(
+        "thumbnail_renderer",
+        [
+            {},
+            {"thumbnailRenderer": {}},
+            {"thumbnailRenderer": {"musicThumbnailRenderer": {}}},
+            {"thumbnailRenderer": {"musicThumbnailRenderer": {"thumbnail": {}}}},
+        ],
+        ids=["absent", "empty_renderer", "empty_music_renderer", "empty_thumbnail"],
+    )
+    def test_missing_thumbnails(self, thumbnail_renderer):
+        parsed = parse_playlist(_playlist_item(thumbnail_renderer))
+        assert parsed["playlistId"] == "PLabc123"
+        assert parsed["thumbnails"] is None

--- a/ytmusicapi/parsers/browsing.py
+++ b/ytmusicapi/parsers/browsing.py
@@ -167,7 +167,7 @@ def parse_playlist(data: JsonDict) -> JsonDict:
             none_if_absent=True,  # rare but possible for playlist title to be missing
         ),
         "playlistId": nav(data, TITLE + NAVIGATION_BROWSE_ID)[2:],
-        "thumbnails": nav(data, THUMBNAIL_RENDERER),
+        "thumbnails": nav(data, THUMBNAIL_RENDERER, True),
     }
     subtitle = data["subtitle"]
     if "runs" in subtitle:


### PR DESCRIPTION
`parse_playlist` reads the thumbnail with `nav(data, THUMBNAIL_RENDERER)` and no `none_if_absent`. Some library shelf cards return a thumbnail renderer with an empty `thumbnail` object. `nav` then raises:

```
KeyError: "Unable to find 'thumbnails' using path ['thumbnailRenderer', 'musicThumbnailRenderer', 'thumbnail', 'thumbnails'] on {}, exception: 'thumbnails'"
```

`parse_content_list` has no per-item error handling, so one such card makes the whole `get_library_playlists()` call fail. The user gets no playlists at all.

The `title` field in the same function already guards against this case. `parse_video` and `parse_related_artist` in the same module also read the thumbnail with `none_if_absent`.

Reported downstream at music-assistant/support#6011.

## Changes

- `parse_playlist` returns `thumbnails: None` instead of raising when the thumbnail is absent or empty.
- Added `tests/parsers/test_browsing.py` covering the four shapes: no renderer, empty renderer, empty music renderer, and empty thumbnail object.
