### PR TITLE
test: skip podcast search results without a browseId

### DIFF
--- a/tests/mixins/test_podcasts.py
+++ b/tests/mixins/test_podcasts.py
@@ -29,8 +29,10 @@ class TestPodcasts:
     def test_many_podcasts(self, yt):
         results = yt.search("europe", filter="podcasts")
         for result in results:
-            results = yt.get_podcast(result["browseId"])
-            assert len(results) > 0
+            if result["browseId"] is None:
+                continue  # search can surface non-podcast results even with the podcasts filter
+            podcast = yt.get_podcast(result["browseId"])
+            assert len(podcast) > 0
 
     def test_get_episode(self, config, yt, yt_brand):
         episode_id = config["podcasts"]["episode_id"]


### PR DESCRIPTION
## Summary
- `test_many_podcasts` calls `yt.search("europe", filter="podcasts")` and passes every result's `browseId` straight into `get_podcast()`.
- Search with the `podcasts` filter can surface results (e.g. episodes) that don't have a `browseId`, since `ytmusicapi/parsers/search.py:65` reads it with `none_if_absent=True`.
- When that happens, `get_podcast(None)` raises `AttributeError: 'NoneType' object has no attribute 'startswith'` in `ytmusicapi/mixins/podcasts.py:136`, failing CI (seen on PR #972: https://github.com/sigma67/ytmusicapi/actions/runs/31269845020/job/93133837902).
- `test_many_episodes` right below already tolerates a similar case (episodes that are no longer available); this applies the same pattern here.

## Test plan
- [x] `ruff check` / `ruff format` / `mypy` pass via pre-commit hooks
- [ ] CI run passes (live API test, can't be run locally without credentials)