### PR TITLE
ci: run checks for ytmusicapi-2

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - ytmusicapi-2
     paths:
       - ytmusicapi/**
       - tests/**

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+      - ytmusicapi-2
     paths:
       - ytmusicapi/**
       - tests/**


### PR DESCRIPTION
Closes #979.

Adds `ytmusicapi-2` to the branch filters used by the CI workflows:

- Ruff and mypy run for pull requests targeting `ytmusicapi-2`.
- Tests and coverage run for pushes to `ytmusicapi-2`.

The coverage workflow uses `pull_request_target` without a branch restriction, so it already applies to pull requests targeting the v2 branch.

Validation performed:

- Parsed both workflow files successfully.
- Confirmed the lint workflow targets `main` and `ytmusicapi-2` pull requests.
- Confirmed the coverage workflow targets pushes to `main` and `ytmusicapi-2`, while accepting all pull request target branches.
- `git diff --check` passed.

Once `ytmusicapi-2` is available and includes this change, the final behavior can be verified with a real pull request targeting that branch.