### PR TITLE
Parse isAvailable for song/video search results

### DIFF
--- a/tests/parsers/test_search.py
+++ b/tests/parsers/test_search.py
@@ -1,0 +1,39 @@
+from ytmusicapi.parsers.search import parse_search_result
+
+
+def _flex_result(**extra: str) -> dict:
+    result = {
+        "flexColumns": [
+            {"musicResponsiveListItemFlexColumnRenderer": {"text": {"runs": [{"text": "Song Title"}]}}},
+            {"musicResponsiveListItemFlexColumnRenderer": {"text": {"runs": [{"text": "Artist"}]}}},
+        ],
+    }
+    result.update(extra)
+    return result
+
+
+class TestParseSearchResultIsAvailable:
+    def test_defaults_to_available(self):
+        parsed = parse_search_result(_flex_result(), "song", "Songs")
+        assert parsed["isAvailable"] is True
+
+    def test_grey_out_policy_marks_unavailable(self):
+        parsed = parse_search_result(
+            _flex_result(musicItemRendererDisplayPolicy="MUSIC_ITEM_RENDERER_DISPLAY_POLICY_GREY_OUT"),
+            "video",
+            "Videos",
+        )
+        assert parsed["isAvailable"] is False
+
+    def test_other_policy_values_remain_available(self):
+        parsed = parse_search_result(
+            _flex_result(musicItemRendererDisplayPolicy="MUSIC_ITEM_RENDERER_DISPLAY_POLICY_DEFAULT"),
+            "song",
+            "Songs",
+        )
+        assert parsed["isAvailable"] is True
+
+    def test_other_result_types_are_unaffected(self):
+        # isAvailable is only meaningful for playable song/video results
+        parsed = parse_search_result(_flex_result(), "album", "Albums")
+        assert "isAvailable" not in parsed

--- a/ytmusicapi/mixins/search.py
+++ b/ytmusicapi/mixins/search.py
@@ -73,8 +73,7 @@ class SearchMixin(MixinProtocol):
                 "views": "1.4M",
                 "videoType": "MUSIC_VIDEO_TYPE_OMV",
                 "duration": "4:38",
-                "duration_seconds": 278,
-                "isAvailable": true
+                "duration_seconds": 278
               },
               {
                 "category": "Songs",

--- a/ytmusicapi/mixins/search.py
+++ b/ytmusicapi/mixins/search.py
@@ -73,7 +73,8 @@ class SearchMixin(MixinProtocol):
                 "views": "1.4M",
                 "videoType": "MUSIC_VIDEO_TYPE_OMV",
                 "duration": "4:38",
-                "duration_seconds": 278
+                "duration_seconds": 278,
+                "isAvailable": true
               },
               {
                 "category": "Songs",
@@ -91,7 +92,8 @@ class SearchMixin(MixinProtocol):
                   "id": "MPREb_9nqEki4ZDpp"
                 },
                 "duration": "4:19",
-                "duration_seconds": 259
+                "duration_seconds": 259,
+                "isAvailable": true,
                 "isExplicit": false,
                 "inLibrary": false,
                 "feedbackTokens": {
@@ -138,7 +140,8 @@ class SearchMixin(MixinProtocol):
                 ],
                 "views": "386M",
                 "duration": "4:38",
-                "duration_seconds": 278
+                "duration_seconds": 278,
+                "isAvailable": true
               },
               {
                 "category": "Artists",

--- a/ytmusicapi/parsers/search.py
+++ b/ytmusicapi/parsers/search.py
@@ -182,6 +182,14 @@ def parse_search_result(data: JsonDict, result_type: str | None, category: str |
         )
         search_result["videoType"] = video_type
 
+    if result_type in ["song", "video"]:
+        isAvailable = True
+        if "musicItemRendererDisplayPolicy" in data:
+            isAvailable = (
+                data["musicItemRendererDisplayPolicy"] != "MUSIC_ITEM_RENDERER_DISPLAY_POLICY_GREY_OUT"
+            )
+        search_result["isAvailable"] = isAvailable
+
     if result_type in ["song", "video", "album"]:
         search_result["duration"] = None
         search_result["year"] = None


### PR DESCRIPTION
Search results currently carry no availability signal: when YouTube Music marks an item as unavailable for the requesting account or region, it sets `musicItemRendererDisplayPolicy: MUSIC_ITEM_RENDERER_DISPLAY_POLICY_GREY_OUT` on the `musicResponsiveListItemRenderer` (the item shows greyed out in the web client). The playlist parser already translates this into `isAvailable`, but `parse_search_result` ignores it, so consumers treat every search hit as playable and only find out when playback fails (see music-assistant/support#6154 for a downstream report).

Changes:
- `parse_search_result` now sets `isAvailable` on `song` and `video` results, mirroring the existing logic in `parsers/playlists.py` (defaults to `true`).
- Documented the new field in the `search()` docstring examples.
- Added pure-unit parser tests in `tests/parsers/test_search.py`.

`pytest tests/parsers/` passes (59 tests, 4 new); ruff and mypy are clean on the touched files. I couldn't extend the live-API search tests as I have no way to reliably trigger a greyed-out result across accounts/regions.