### PR TITLE
feat(models): add pydantic and the YTMusicModel dict-compatible base

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,5 +31,5 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
-      - run: pip install mypy==2.3.0
+      - run: pip install mypy==2.3.0 pydantic
       - run:  mypy --install-types --non-interactive

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,5 +14,5 @@ repos:
   hooks:
   -   id: mypy
       verbose: true
-      additional_dependencies: [ 'types-requests' ]
+      additional_dependencies: [ 'types-requests', 'pydantic>=2' ]
       pass_filenames: false

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:922ddb3a11f6701dbe82d9b22bd514537661df54652eb146c6a542e7810799fa"
+content_hash = "sha256:7678a0ecfcfab934f7e977110a87ac3b476cb69c6916f77fccb25bfb03105e8a"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -19,6 +19,17 @@ groups = ["dev"]
 files = [
     {file = "alabaster-0.7.16-py3-none-any.whl", hash = "sha256:b46733c07dce03ae4e150330b975c75737fa60f0a7c591b6c8bf4928a28e2c92"},
     {file = "alabaster-0.7.16.tar.gz", hash = "sha256:75a8b99c28a5dad50dd7f8ccdd447a121ddb3892da9e53d1ca5cca3106d58d65"},
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.8.0"
+requires_python = ">=3.10"
+summary = "Reusable constraint types to use with typing.Annotated"
+groups = ["default"]
+files = [
+    {file = "annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0"},
+    {file = "annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7"},
 ]
 
 [[package]]
@@ -766,6 +777,133 @@ files = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+requires_python = ">=3.9"
+summary = "Data validation using Python type hints"
+groups = ["default"]
+dependencies = [
+    "annotated-types>=0.6.0",
+    "pydantic-core==2.46.4",
+    "typing-extensions>=4.14.1",
+    "typing-inspection>=0.4.2",
+]
+files = [
+    {file = "pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba"},
+    {file = "pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6"},
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+requires_python = ">=3.9"
+summary = "Core functionality for Pydantic validation and serialization"
+groups = ["default"]
+dependencies = [
+    "typing-extensions>=4.14.1",
+]
+files = [
+    {file = "pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a396dcc17e5a0b164dbe026896245a4fa9ff402edca1dff0be3d53a517f74de4"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb63e0198ca18aad131c089b9204c23079c3afa95487e561f4c522d519e55aba"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f47286a97f0bc9b8859519809077b91b2cefe4ae47fcbf5e466a009c1c5d742b"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:905a0ed8ea6f2d61c1738835f99b699348d7857379083e5fc497fa0c967a407c"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea793e075b70290d89d8142074262885d3f7da19634845135751bd6344f73b50"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:395aebd9183f9d112f569aeb5b2214d1a10a33bec8456447f7fbdfa51d38d4cd"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:b078afbc25f3a1436c7a1d2cd3e322497ee99615ba97c563566fdf46aff1ee01"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f747929cf940cddb5b3668a390056ddd5ba2e5010615ea2dcf4f9c4f3ab8791d"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:daa27d92c36f24388fe3ad306b174781c747627f134452e4f128ea00ce1fe8c4"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:19e51f073cd3df251856a8a4189fbdf1de4012c3ebacfb1884f94f1eb406079f"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c1747f85cee84c26985853c6f3d9bd3e75da5212912443fa111c113b9c246f39"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-win32.whl", hash = "sha256:2f84c03c8607173d16b5a854ec68a2f9079ae03237a54fb506d13af47e1d018d"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-win_amd64.whl", hash = "sha256:8358a950c8909158e3df31538a7e4edc2d7265a7c54b47f0864d9e5bae9dcebf"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983"},
+    {file = "pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1"},
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 requires_python = ">=3.8"
@@ -1107,10 +1245,24 @@ name = "typing-extensions"
 version = "4.15.0"
 requires_python = ">=3.9"
 summary = "Backported and Experimental Type Hints for Python 3.9+"
-groups = ["dev"]
+groups = ["default", "dev"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.4"
+requires_python = ">=3.10"
+summary = "Runtime typing introspection tools"
+groups = ["default"]
+dependencies = [
+    "typing-extensions>=4.15.0",
+]
+files = [
+    {file = "typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147"},
+    {file = "typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "sigma67", email = "ytmusicapi@gmail.com" }]
 license-files = ["LICENSE"]
 license = "MIT"
 classifiers = ["Programming Language :: Python :: 3"]
-dependencies = ["requests >= 2.22"]
+dependencies = ["requests >= 2.22", "pydantic >= 2"]
 dynamic = ["version", "readme"]
 
 [project.scripts]

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -1,0 +1,160 @@
+import pytest
+
+from ytmusicapi.models.base import YTMusicModel
+
+
+class Track(YTMusicModel):
+    videoId: str
+    title: str
+    count: int | None = None
+
+
+@pytest.fixture(name="track")
+def fixture_track() -> Track:
+    return Track(videoId="abc", title="Wonderwall")
+
+
+class TestItemAccess:
+    def test_getitem_returns_field_value(self, track: Track) -> None:
+        assert track["title"] == "Wonderwall"
+
+    def test_getitem_returns_none_for_unset_declared_field(self, track: Track) -> None:
+        assert track["count"] is None
+
+    def test_getitem_raises_keyerror_for_undeclared_field(self, track: Track) -> None:
+        with pytest.raises(KeyError):
+            track["nope"]
+
+    def test_get_returns_field_value(self, track: Track) -> None:
+        assert track.get("title") == "Wonderwall"
+
+    def test_get_returns_none_for_unset_declared_field(self, track: Track) -> None:
+        assert track.get("count") is None
+
+    def test_get_returns_default_for_undeclared_field(self, track: Track) -> None:
+        assert track.get("nope", "fallback") == "fallback"
+
+    def test_get_defaults_to_none(self, track: Track) -> None:
+        assert track.get("nope") is None
+
+    def test_attribute_access_still_works(self, track: Track) -> None:
+        assert track.title == "Wonderwall"
+
+
+class TestContains:
+    def test_declared_field_is_present(self, track: Track) -> None:
+        assert "title" in track
+
+    def test_unset_declared_field_is_still_present(self, track: Track) -> None:
+        assert "count" in track
+
+    def test_undeclared_field_is_absent(self, track: Track) -> None:
+        assert "nope" not in track
+
+    def test_non_string_key_is_absent(self, track: Track) -> None:
+        assert 1 not in track
+
+
+class TestMappingViews:
+    def test_keys_are_in_declaration_order(self, track: Track) -> None:
+        assert list(track.keys()) == ["videoId", "title", "count"]
+
+    def test_values_include_none_for_unset_fields(self, track: Track) -> None:
+        assert list(track.values()) == ["abc", "Wonderwall", None]
+
+    def test_items_pair_keys_with_values(self, track: Track) -> None:
+        assert list(track.items()) == [("videoId", "abc"), ("title", "Wonderwall"), ("count", None)]
+
+    def test_iter_yields_keys_in_declaration_order(self, track: Track) -> None:
+        assert list(track) == ["videoId", "title", "count"]
+
+    def test_len_counts_every_declared_field(self, track: Track) -> None:
+        assert len(track) == 3
+
+    def test_dict_conversion_uses_the_mapping_protocol(self, track: Track) -> None:
+        assert dict(track) == {"videoId": "abc", "title": "Wonderwall", "count": None}
+
+    def test_double_star_unpacking(self, track: Track) -> None:
+        assert {**track} == {"videoId": "abc", "title": "Wonderwall", "count": None}
+
+
+class TestEquality:
+    def test_equal_to_plain_dict_with_same_content(self, track: Track) -> None:
+        assert track == {"videoId": "abc", "title": "Wonderwall", "count": None}
+
+    def test_dict_on_the_left_is_also_equal(self, track: Track) -> None:
+        assert {"videoId": "abc", "title": "Wonderwall", "count": None} == track
+
+    def test_not_equal_to_dict_omitting_a_none_valued_field(self, track: Track) -> None:
+        assert track != {"videoId": "abc", "title": "Wonderwall"}
+
+    def test_not_equal_to_dict_with_different_value(self, track: Track) -> None:
+        assert track != {"videoId": "abc", "title": "Champagne Supernova", "count": None}
+
+    def test_equal_to_identical_model(self, track: Track) -> None:
+        assert track == Track(videoId="abc", title="Wonderwall")
+
+    def test_not_equal_to_different_model(self, track: Track) -> None:
+        assert track != Track(videoId="xyz", title="Wonderwall")
+
+    def test_not_equal_to_unrelated_type(self, track: Track) -> None:
+        assert track != "Wonderwall"
+
+    def test_nested_model_compares_against_nested_plain_dict(self) -> None:
+        class Album(YTMusicModel):
+            name: str
+            track: Track
+
+        album = Album(name="Morning Glory", track=Track(videoId="abc", title="Wonderwall"))
+        assert album == {
+            "name": "Morning Glory",
+            "track": {"videoId": "abc", "title": "Wonderwall", "count": None},
+        }
+
+    def test_list_of_models_compares_against_list_of_dicts(self) -> None:
+        class Playlist(YTMusicModel):
+            tracks: list[Track]
+
+        playlist = Playlist(tracks=[Track(videoId="abc", title="Wonderwall")])
+        assert playlist == {"tracks": [{"videoId": "abc", "title": "Wonderwall", "count": None}]}
+
+
+class TestExtraFields:
+    @pytest.fixture(name="track_with_extra")
+    def fixture_track_with_extra(self) -> Track:
+        return Track(videoId="abc", title="Wonderwall", newFromYtm="surprise")  # type: ignore[call-arg]
+
+    def test_undeclared_field_is_kept(self, track_with_extra: Track) -> None:
+        assert track_with_extra["newFromYtm"] == "surprise"
+
+    def test_undeclared_field_is_contained(self, track_with_extra: Track) -> None:
+        assert "newFromYtm" in track_with_extra
+
+    def test_undeclared_field_comes_after_declared_ones(self, track_with_extra: Track) -> None:
+        assert list(track_with_extra.keys()) == ["videoId", "title", "count", "newFromYtm"]
+
+    def test_undeclared_field_counts_towards_len(self, track_with_extra: Track) -> None:
+        assert len(track_with_extra) == 4
+
+    def test_undeclared_field_takes_part_in_dict_equality(self, track_with_extra: Track) -> None:
+        assert track_with_extra == {
+            "videoId": "abc",
+            "title": "Wonderwall",
+            "count": None,
+            "newFromYtm": "surprise",
+        }
+
+
+class TestJsonRoundTrip:
+    def test_model_dump_omits_nothing(self, track: Track) -> None:
+        assert track.model_dump() == {"videoId": "abc", "title": "Wonderwall", "count": None}
+
+    def test_parses_from_a_raw_dict(self) -> None:
+        raw = {"videoId": "abc", "title": "Wonderwall"}
+        assert Track(**raw) == {"videoId": "abc", "title": "Wonderwall", "count": None}
+
+
+def test_exported_from_the_models_package() -> None:
+    from ytmusicapi.models import YTMusicModel as Exported
+
+    assert Exported is YTMusicModel

--- a/ytmusicapi/models/__init__.py
+++ b/ytmusicapi/models/__init__.py
@@ -1,3 +1,4 @@
+from .base import YTMusicModel
 from .lyrics import LyricLine, Lyrics, TimedLyrics
 
-__all__ = ["LyricLine", "Lyrics", "TimedLyrics"]
+__all__ = ["LyricLine", "Lyrics", "TimedLyrics", "YTMusicModel"]

--- a/ytmusicapi/models/base.py
+++ b/ytmusicapi/models/base.py
@@ -1,0 +1,55 @@
+from collections.abc import ItemsView, Iterator, KeysView, ValuesView
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class YTMusicModel(BaseModel):
+    """Base class for all response models.
+
+    Supports both attribute and subscript access. Every declared field is always a key:
+    one the API did not return reads back as ``None`` rather than raising or being absent.
+    """
+
+    # parsers may emit fields a model has not declared yet; keep them rather than drop them
+    model_config = ConfigDict(extra="allow")
+
+    def _as_dict(self) -> dict[str, Any]:
+        """Declared fields in declaration order, then undeclared ones in arrival order.
+
+        Values are left as-is, so nested models keep comparing via their own ``__eq__``.
+        """
+        data: dict[str, Any] = {name: getattr(self, name) for name in type(self).model_fields}
+        data.update(self.model_extra or {})
+        return data
+
+    def __getitem__(self, key: str) -> Any:
+        if key not in self:
+            raise KeyError(key)
+        return getattr(self, key)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return getattr(self, key) if key in self else default
+
+    def __contains__(self, key: object) -> bool:
+        return key in type(self).model_fields or key in (self.model_extra or {})
+
+    def keys(self) -> KeysView[str]:
+        return self._as_dict().keys()
+
+    def values(self) -> ValuesView[Any]:
+        return self._as_dict().values()
+
+    def items(self) -> ItemsView[str, Any]:
+        return self._as_dict().items()
+
+    def __iter__(self) -> Iterator[str]:  # type: ignore[override]
+        return iter(self._as_dict())
+
+    def __len__(self) -> int:
+        return len(type(self).model_fields) + len(self.model_extra or {})
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, dict):
+            return self._as_dict() == other
+        return super().__eq__(other)


### PR DESCRIPTION
Part of #307. Closes #980. Base branch: `ytmusicapi-2`.

Adds the pydantic dependency and the shared base class every response model will derive from. Touches no endpoint and changes no return type.

## What's here

`ytmusicapi/models/base.py` — `YTMusicModel(BaseModel)` implementing the mapping protocol so subscript-style consumer code keeps working alongside attribute access: `__getitem__`, `get`, `__contains__`, `keys`, `values`, `items`, `__iter__`, `__len__`, `__eq__` against plain dicts.

`__iter__` yields keys (not pydantic's `(key, value)` tuples), so `dict(model)` and `{**model}` go through the mapping protocol and behave as consumers expect. Values are passed through un-converted rather than deep-dumped, so nested models keep comparing via their own `__eq__` — `album == {"name": ..., "track": {...}}` recurses correctly, as does a list of models against a list of dicts.

## Semantics

Every declared field is always a key. A field the API did not return is present with value `None`, not absent:

```python
"count" in playlist    # True, even when YTM returned no count
playlist.get("count")  # None
playlist["count"]      # None, not KeyError
```

This is the one deliberate behaviour change in #307 and the reason it targets 2.0.

## Open decision: settled as proposed

`model_config = ConfigDict(extra="allow")`. A field a parser emits but a model has not declared yet still reaches the consumer instead of being silently dropped. Extras participate fully in the mapping protocol — they show up in `keys`/`values`/`items`, count towards `__len__`, satisfy `in`, and take part in dict equality — ordered after the declared fields.

## Beyond the literal scope

Neither the `mypy` lint job nor the pre-commit mypy hook installs runtime dependencies, so both would have failed on the new import with `Class cannot subclass "BaseModel" (has type "Any")`. `pydantic` is added to both. The pre-commit hook caught this on the first commit attempt, which is how we know CI would have too.

`pdm.lock` is regenerated (pydantic 2.13.4, pydantic-core 2.46.4) since `pdm install` in CI installs from it.

## Definition of done

- [x] Exhaustive unit tests for the mapping protocol — 36 in `tests/models/test_base.py`, covering equality with plain dicts (both operand orders, nested dicts, lists of dicts), iteration order, `None`-valued fields, non-string keys, extra-field behaviour, and the package re-export. Written test-first and watched fail.
- [x] `mypy --strict` clean — mypy 2.3.0, the version CI pins, 52 source files.
- [x] No existing test changes behaviour — nothing existing imports the new module. `ruff check`, `ruff format --check`, and the 89 offline tests (`tests/models` + `tests/parsers`) all pass. The live-API suites were not run locally; they need credentials and hit the shared test account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)