### PR TITLE
test: replace unavailable audiobook playlist in get_playlist test

### DIFF
--- a/tests/mixins/test_playlists.py
+++ b/tests/mixins/test_playlists.py
@@ -108,7 +108,7 @@ class TestPlaylists:
         "playlist_id",
         [
             "OLAK5uy_nT1mL8aZvxqfIRFN9L8FgIzfvk6HUkd0I",  # Show
-            "OLAK5uy_ksLYkcnrOSKYl62uxB3ga2zfBZfCuvnJ4",  # Audiobook
+            "OLAK5uy_kIzblCjlA2EThP40umbI81GfLrDaOhp5s",  # Audiobook
         ],
     )
     def test_get_playlist_audiobook(self, yt, playlist_id):


### PR DESCRIPTION
`test_get_playlist_audiobook[OLAK5uy_ksLYkcnrOSKYl62uxB3ga2zfBZfCuvnJ4]` has been failing on main with:

```
KeyError: "Unable to find 'contents' using path ['contents', 'twoColumnBrowseResultsRenderer', 'secondaryContents', 'sectionListRenderer']"
```

The browse response for that playlist now comes back with only `microformat`, `responseContext` and `trackingParams` — no `contents` at all. Confirmed it is not a parser regression: the same empty response comes back unauthenticated, authenticated, and with `location="GB"`, so the audiobook is simply no longer retrievable.

Replaced it with `OLAK5uy_kIzblCjlA2EThP40umbI81GfLrDaOhp5s` (The Great Gatsby, search result type `Audiobook`). The `Show` parameter is untouched and still passes.

```
tests/mixins/test_playlists.py::TestPlaylists::test_get_playlist_audiobook - 2 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)