### PR TITLE
fix(search): match filtered shelf category through the locale catalog

### DIFF
--- a/tests/mixins/test_search.py
+++ b/tests/mixins/test_search.py
@@ -5,6 +5,7 @@ import pytest
 
 from ytmusicapi import YTMusic
 from ytmusicapi.exceptions import YTMusicUserError
+from ytmusicapi.navigation import MRLIR
 from ytmusicapi.parsers.search import ALL_RESULT_TYPES, API_RESULT_TYPES
 
 STANFORD_PODCAST_SEARCH_QUERY = 'intitle:"109. Simplify!" before:2024-01-01 after:2023-01-01'
@@ -195,6 +196,59 @@ class TestSearch:
             yt_oauth.search("beatles", filter="community_playlists", scope="library", limit=40)
         with pytest.raises(YTMusicUserError):
             yt_oauth.search("beatles", filter="featured_playlists", scope="library", limit=40)
+
+    def _flex_item(self, title: str) -> dict:
+        return {
+            MRLIR: {
+                "flexColumns": [
+                    {"musicResponsiveListItemFlexColumnRenderer": {"text": {"runs": [{"text": title}]}}},
+                    {"musicResponsiveListItemFlexColumnRenderer": {"text": {"runs": [{"text": "Artist"}]}}},
+                ]
+            }
+        }
+
+    def _shelf_response(self, shelf_title: str, item_titles: list[str]) -> dict:
+        return {
+            "contents": {
+                "sectionListRenderer": {
+                    "contents": [
+                        {
+                            "musicShelfRenderer": {
+                                "title": {"runs": [{"text": shelf_title}]},
+                                "contents": [self._flex_item(title) for title in item_titles],
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+    def test_search_filtered_localized_shelf_title_is_matched(self, monkeypatch: pytest.MonkeyPatch):
+        """Regression test for #1006.
+
+        The shelf's category text is localized (e.g. Korean "앨범" for "Albums"),
+        so matching a filter against it must go through the same gettext catalog
+        used to translate the shelf title in the first place, rather than the
+        raw English filter stem.
+        """
+        yt_ko = YTMusic(language="ko")
+        response = self._shelf_response("앨범", ["Test Album"])
+        monkeypatch.setattr(yt_ko, "_send_request", lambda endpoint, body, additionalParams="": response)
+
+        results = yt_ko.search("test", filter="albums")
+
+        assert len(results) == 1
+        assert results[0]["resultType"] == "album"
+
+    def test_search_filtered_mismatched_shelf_is_still_skipped(self, monkeypatch: pytest.MonkeyPatch):
+        """A shelf that genuinely doesn't match the requested filter is still dropped."""
+        yt_ko = YTMusic(language="ko")
+        response = self._shelf_response("노래", ["Test Song"])  # "Songs", padded into an albums search
+        monkeypatch.setattr(yt_ko, "_send_request", lambda endpoint, body, additionalParams="": response)
+
+        results = yt_ko.search("test", filter="albums")
+
+        assert results == []
 
     @pytest.mark.xdist_group("search_history")
     def test_remove_search_suggestions_valid(self, yt_auth):

--- a/ytmusicapi/mixins/search.py
+++ b/ytmusicapi/mixins/search.py
@@ -270,8 +270,12 @@ class SearchMixin(MixinProtocol):
             ):
                 # YTM sometimes pads results with a differently-categorized shelf
                 # (e.g. a "Songs" shelf when filtering by featured_playlists) - skip
-                # it rather than mislabeling its contents as the requested type
-                if category and internal_filter[:-1].lower() not in category.lower():
+                # it rather than mislabeling its contents as the requested type.
+                # The shelf's category text is localized, so translate the expected
+                # category through the same gettext catalog instead of comparing
+                # against the English filter stem directly.
+                expected_category = self.parser.lang.gettext(internal_filter[:-1])
+                if category and expected_category.lower() not in category.lower():
                     continue
                 result_type = internal_filter[:-1].lower()
 


### PR DESCRIPTION
Closes #1006.

`SearchMixin.search()` skips a shelf whose rendered category text doesn't match the requested filter, to avoid mislabeling a padding shelf YTM sometimes adds (e.g. a "Songs" shelf padded into a `featured_playlists` search — see #975). That check compares the shelf's *localized* title against the raw English filter stem:

```python
if category and internal_filter[:-1].lower() not in category.lower():
    continue
```

For `language="ko"` the rendered shelf title is `앨범`/`아티스트`, which never contains `"album"`/`"artist"`, so the shelf is always skipped and `albums`/`artists` filtered searches return `[]` — reported in the issue with a full repro (`ko albums 0`, `ko artists 0`, `en albums 20`, `en artists 4`).

The fix translates the expected category through the same `gettext` catalog already used to render the shelf title (`self.parser.lang`, the mechanism `Parser.get_search_result_types()` and `parse_channel_contents` already use for this exact kind of comparison) instead of comparing against English directly:

```python
expected_category = self.parser.lang.gettext(internal_filter[:-1])
if category and expected_category.lower() not in category.lower():
    continue
```

Two tests added in `tests/mixins/test_search.py` (no network required — `_send_request` is monkeypatched with a minimal Korean-shelf response):
- a matching localized shelf (`앨범`) is no longer dropped for `filter="albums"` — fails without the fix (`assert 0 == 1`), passes with it
- a genuinely mismatched shelf (`노래`/"songs" padded into an albums search) is still correctly skipped, so the original padding-shelf protection from #975 is preserved

`ruff check`, `ruff format --check`, and `mypy` pass on the changed files.