### PR TITLE
feat(models): response models for the upload-library methods

### DIFF
--- a/tests/parsers/test_uploads.py
+++ b/tests/parsers/test_uploads.py
@@ -1,0 +1,206 @@
+from ytmusicapi.continuations import get_continuations
+from ytmusicapi.models.content.enums import LikeStatus
+from ytmusicapi.models.uploads import UploadAlbum, UploadSong
+from ytmusicapi.parsers.uploads import parse_upload_album, parse_uploaded_items
+
+ARTIST_ID = "FEmusic_library_privately_owned_artist_detaila_po_CICr2crg7OWpchIIY29sZHBsYXk"
+ALBUM_ID = "FEmusic_library_privately_owned_release_detailb_po_55chars"
+
+
+def _menu(video_id: str, entity_id: str, like_status: str = "LIKE") -> dict:
+    delete_command = {
+        "confirmDialogEndpoint": {
+            "content": {
+                "confirmDialogRenderer": {
+                    "confirmButton": {
+                        "buttonRenderer": {
+                            "command": {"musicDeletePrivatelyOwnedEntityCommand": {"entityId": entity_id}}
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return {
+        "menuRenderer": {
+            "items": [
+                {
+                    "menuServiceItemRenderer": {
+                        "serviceEndpoint": {"queueAddEndpoint": {"queueTarget": {"videoId": video_id}}}
+                    }
+                },
+                {"menuNavigationItemRenderer": {"navigationEndpoint": delete_command}},
+            ],
+            "topLevelButtons": [{"likeButtonRenderer": {"likeStatus": like_status}}],
+        }
+    }
+
+
+def _flex_column(run: dict) -> dict:
+    return {"musicResponsiveListItemFlexColumnRenderer": {"text": {"runs": [run]}}}
+
+
+def _linked_run(text: str, browse_id: str) -> dict:
+    return {"text": text, "navigationEndpoint": {"browseEndpoint": {"browseId": browse_id}}}
+
+
+def _upload_song_item(like_status: str = "LIKE") -> dict:
+    return {
+        "musicResponsiveListItemRenderer": {
+            "menu": _menu("Uise6RPKoek", "t_po_CICr2crg7OWpchDpjPjrBA", like_status),
+            "flexColumns": [
+                _flex_column({"text": "A Sky Full Of Stars"}),
+                _flex_column(_linked_run("Coldplay", ARTIST_ID)),
+                _flex_column(_linked_run("Ghost Stories", ALBUM_ID)),
+            ],
+            "fixedColumns": [
+                {"musicResponsiveListItemFixedColumnRenderer": {"text": {"runs": [{"text": "4:15"}]}}}
+            ],
+            "thumbnail": {
+                "musicThumbnailRenderer": {
+                    "thumbnail": {
+                        "thumbnails": [
+                            {"url": "https://i.ytimg.com/vi/Uise6RPKoek/s.jpg", "width": 60, "height": 60}
+                        ]
+                    }
+                }
+            },
+        }
+    }
+
+
+class TestParseUploadedItems:
+    def test_parses_uploaded_song(self):
+        song = parse_uploaded_items([_upload_song_item()])[0]
+
+        assert isinstance(song, UploadSong)
+        assert song["entityId"] == "t_po_CICr2crg7OWpchDpjPjrBA"
+        assert song.videoId == "Uise6RPKoek"
+        assert song.title == "A Sky Full Of Stars"
+        assert song.duration == "4:15"
+        assert song.duration_seconds == 255
+        assert song.artists[0].name == "Coldplay"
+        assert song.artists[0].id == ARTIST_ID
+        assert song.album.name == "Ghost Stories"
+        assert song.album.id == ALBUM_ID
+        assert song.likeStatus == "LIKE"
+        assert song.thumbnails[0].url == "https://i.ytimg.com/vi/Uise6RPKoek/s.jpg"
+
+    # missing data stays a present key with None value, per the #307 semantics
+    def test_missing_fields_are_present_with_none(self):
+        item = _upload_song_item()
+        del item["musicResponsiveListItemRenderer"]["fixedColumns"]
+        del item["musicResponsiveListItemRenderer"]["flexColumns"][2]
+        del item["musicResponsiveListItemRenderer"]["thumbnail"]
+
+        song = parse_uploaded_items([item])[0]
+
+        assert song.duration is None
+        assert song.duration_seconds is None
+        assert song.album is None
+        assert song.thumbnails is None
+        assert {"duration", "duration_seconds", "album", "thumbnails"} <= set(song)
+
+    def test_unknown_like_status_maps_to_indifferent(self):
+        song = parse_uploaded_items([_upload_song_item(like_status="SOMETHING_ELSE")])[0]
+
+        assert song.likeStatus is LikeStatus.INDIFFERENT
+
+    def test_item_without_menu_is_skipped(self):
+        item = _upload_song_item()
+        del item["musicResponsiveListItemRenderer"]["menu"]
+
+        assert parse_uploaded_items([item]) == []
+
+    def test_dict_access_matches_attribute_access(self):
+        song = parse_uploaded_items([_upload_song_item()])[0]
+
+        assert song["title"] == song.title
+        assert song.get("entityId") == song.entityId
+
+
+def test_continuations_with_model_parse_func():
+    shelf = {
+        "contents": [_upload_song_item()],
+        "continuations": [{"nextContinuationData": {"continuation": "ctoken1"}}],
+    }
+    continuation_response = {
+        "continuationContents": {
+            "musicShelfContinuation": {"contents": [_upload_song_item(like_status="INDIFFERENT")]}
+        }
+    }
+
+    def request_func(additional_params: str) -> dict:
+        assert "ctoken1" in additional_params
+        return continuation_response
+
+    # the caller parses the first page itself; get_continuations returns only
+    # the continuation pages, composed the same way the mixin composes them
+    songs = parse_uploaded_items(shelf["contents"])
+    songs.extend(get_continuations(shelf, "musicShelfContinuation", 100, request_func, parse_uploaded_items))
+
+    assert len(songs) == 2
+    assert all(isinstance(song, UploadSong) for song in songs)
+    assert songs[0].likeStatus == LikeStatus.LIKE
+    assert songs[1].likeStatus == LikeStatus.INDIFFERENT
+
+
+def _album_response(track_items: list[dict]) -> dict:
+    header = {
+        "musicDetailHeaderRenderer": {
+            "title": {"runs": [{"text": "18 Months"}]},
+            "subtitle": {
+                "runs": [
+                    {"text": "Album"},
+                    {"text": " • "},
+                    _linked_run("Calvin Harris", ARTIST_ID),
+                    {"text": " • "},
+                    {"text": "2012"},
+                ]
+            },
+            "secondSubtitle": {"runs": [{"text": "2"}, {"text": " songs"}, {"text": "8 minutes"}]},
+            "menu": {
+                "menuRenderer": {
+                    "topLevelButtons": [
+                        {
+                            "buttonRenderer": {
+                                "navigationEndpoint": {
+                                    "watchPlaylistEndpoint": {"playlistId": "MLPRb_po_55chars"}
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+        }
+    }
+    shelf = {"sectionListRenderer": {"contents": [{"musicShelfRenderer": {"contents": track_items}}]}}
+    return {
+        "header": header,
+        "contents": {"singleColumnBrowseResultsRenderer": {"tabs": [{"tabRenderer": {"content": shelf}}]}},
+    }
+
+
+class TestParseUploadAlbum:
+    def test_parses_album_with_tracks(self):
+        album = parse_upload_album(_album_response([_upload_song_item()]))
+
+        assert isinstance(album, UploadAlbum)
+        assert album.title == "18 Months"
+        assert album.type == "Album"
+        assert album.artists[0].name == "Calvin Harris"
+        assert album.year == "2012"
+        assert album.trackCount == 2
+        assert album.duration == "8 minutes"
+        assert album.audioPlaylistId == "MLPRb_po_55chars"
+        assert album.description is None
+        assert album.likeStatus is None
+        assert isinstance(album.tracks[0], UploadSong)
+        assert album["tracks"][0]["entityId"] == "t_po_CICr2crg7OWpchDpjPjrBA"
+        # one 4:15 track => 255 seconds total
+        assert album.duration_seconds == 255
+
+    def test_duration_seconds_sums_all_tracks(self):
+        album = parse_upload_album(_album_response([_upload_song_item(), _upload_song_item()]))
+
+        assert album.duration_seconds == 510

--- a/ytmusicapi/continuations.py
+++ b/ytmusicapi/continuations.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Any, cast
+from typing import Any, TypeVar, cast
 
 from ytmusicapi.navigation import nav
 from ytmusicapi.type_alias import (
@@ -10,6 +10,8 @@ from ytmusicapi.type_alias import (
     RequestFuncBodyType,
     RequestFuncType,
 )
+
+T = TypeVar("T")
 
 CONTINUATION_TOKEN = ["continuationItemRenderer", "continuationEndpoint", "continuationCommand", "token"]
 COMMAND_EXECUTOR_COMMANDS = [
@@ -79,10 +81,10 @@ def get_continuations(
     continuation_type: str,
     limit: int | None,
     request_func: RequestFuncType,
-    parse_func: ParseFuncType,
+    parse_func: Callable[[JsonList], list[T]],
     ctoken_path: str = "",
     additionalParams: str | None = None,
-) -> JsonList:
+) -> list[T]:
     """
 
     :param results: result list from request data
@@ -97,7 +99,7 @@ def get_continuations(
     :param additionalParams: Optional additional params to pass to the request func. Default: use get_continuation_params
     :return: list of parsed continuation results
     """
-    items: JsonList = []
+    items: list[T] = []
     while "continuations" in results and (limit is None or len(items) < limit):
         additional_params = additionalParams or get_continuation_params(results, ctoken_path)
         response = request_func(additional_params)
@@ -165,7 +167,7 @@ def get_continuation_string(ctoken: str) -> str:
     return "&ctoken=" + ctoken + "&continuation=" + ctoken
 
 
-def get_continuation_contents(continuation: JsonDict, parse_func: ParseFuncType) -> JsonList:
+def get_continuation_contents(continuation: JsonDict, parse_func: Callable[[JsonList], list[T]]) -> list[T]:
     for term in ["contents", "items"]:
         if term in continuation:
             return parse_func(continuation[term])

--- a/ytmusicapi/mixins/uploads.py
+++ b/ytmusicapi/mixins/uploads.py
@@ -5,16 +5,16 @@ import requests
 
 from ytmusicapi.continuations import get_continuations
 from ytmusicapi.helpers import *
+from ytmusicapi.models.uploads import UploadAlbum, UploadSong
 from ytmusicapi.navigation import *
-from ytmusicapi.parsers.albums import parse_album_header
 from ytmusicapi.parsers.library import (
     get_library_contents,
     parse_library_albums,
     parse_library_artists,
     pop_songs_random_mix,
 )
-from ytmusicapi.parsers.uploads import parse_uploaded_items
-from ytmusicapi.type_alias import JsonDict, JsonList, ParseFuncType, RequestFuncType
+from ytmusicapi.parsers.uploads import parse_upload_album, parse_uploaded_items
+from ytmusicapi.type_alias import JsonDict, JsonList, RequestFuncType
 
 from ..auth.types import AuthType
 from ..enums import ResponseStatus
@@ -26,28 +26,13 @@ from ._utils import LibraryOrderType, prepare_order_params, validate_order_param
 class UploadsMixin(MixinProtocol):
     def get_library_upload_songs(
         self, limit: int | None = 25, order: LibraryOrderType | None = None
-    ) -> JsonList:
+    ) -> list[UploadSong]:
         """
         Returns a list of uploaded songs
 
         :param limit: How many songs to return. ``None`` retrieves them all. Default: 25
         :param order: Order of songs to return. Allowed values: ``a_to_z``, ``z_to_a``, ``recently_added``. Default: Default order.
-        :return: List of uploaded songs.
-
-        Each item is in the following format::
-
-            {
-              "entityId": "t_po_CICr2crg7OWpchDpjPjrBA",
-              "videoId": "Uise6RPKoek",
-              "artists": [{
-                'name': 'Coldplay',
-                'id': 'FEmusic_library_privately_owned_artist_detaila_po_CICr2crg7OWpchIIY29sZHBsYXk',
-              }],
-              "title": "A Sky Full Of Stars",
-              "album": "Ghost Stories",
-              "likeStatus": "LIKE",
-              "thumbnails": [...]
-            }
+        :return: List of uploaded songs, see :py:class:`ytmusicapi.models.uploads.UploadSong`
         """
         self._check_auth()
         endpoint = "browse"
@@ -60,7 +45,7 @@ class UploadsMixin(MixinProtocol):
         if results is None:
             return []
         pop_songs_random_mix(results)
-        songs: JsonList = parse_uploaded_items(results["contents"])
+        songs: list[UploadSong] = parse_uploaded_items(results["contents"])
 
         if "continuations" in results:
             request_func: RequestFuncType = lambda additionalParams: self._send_request(
@@ -117,32 +102,13 @@ class UploadsMixin(MixinProtocol):
             response, lambda additionalParams: self._send_request(endpoint, body, additionalParams), limit
         )
 
-    def get_library_upload_artist(self, browseId: str, limit: int = 25) -> JsonList:
+    def get_library_upload_artist(self, browseId: str, limit: int = 25) -> list[UploadSong]:
         """
         Returns a list of uploaded tracks for the artist.
 
         :param browseId: Browse id of the upload artist, i.e. from :py:func:`get_library_upload_songs`
         :param limit: Number of songs to return (increments of 25).
-        :return: List of uploaded songs.
-
-        Example List::
-
-            [
-              {
-                "entityId": "t_po_CICr2crg7OWpchDKwoakAQ",
-                "videoId": "Dtffhy8WJgw",
-                "title": "Hold Me (Original Mix)",
-                "artists": [
-                  {
-                    "name": "Jakko",
-                    "id": "FEmusic_library_privately_owned_artist_detaila_po_CICr2crg7OWpchIFamFra28"
-                  }
-                ],
-                "album": null,
-                "likeStatus": "LIKE",
-                "thumbnails": [...]
-              }
-            ]
+        :return: List of uploaded songs, see :py:class:`ytmusicapi.models.uploads.UploadSong`
         """
         self._check_auth()
         body = {"browseId": browseId}
@@ -158,7 +124,7 @@ class UploadsMixin(MixinProtocol):
             request_func: RequestFuncType = lambda additionalParams: self._send_request(
                 endpoint, body, additionalParams
             )
-            parse_func: ParseFuncType = lambda contents: parse_uploaded_items(contents)
+            parse_func = lambda contents: parse_uploaded_items(contents)
             remaining_limit = None if limit is None else (limit - len(items))
             items.extend(
                 get_continuations(
@@ -168,47 +134,19 @@ class UploadsMixin(MixinProtocol):
 
         return items
 
-    def get_library_upload_album(self, browseId: str) -> JsonDict:
+    def get_library_upload_album(self, browseId: str) -> UploadAlbum:
         """
         Get information and tracks of an album associated with uploaded tracks
 
         :param browseId: Browse id of the upload album, i.e. from i.e. from :py:func:`get_library_upload_songs`
-        :return: Dictionary with title, description, artist and tracks.
-
-        Example album::
-
-            {
-              "title": "18 Months",
-              "type": "Album",
-              "thumbnails": [...],
-              "trackCount": 7,
-              "duration": "24 minutes",
-              "audioPlaylistId": "MLPRb_po_55chars",
-              "tracks": [
-                {
-                  "entityId": "t_po_22chars",
-                  "videoId": "FVo-UZoPygI",
-                  "title": "Feel So Close",
-                  "duration": "4:15",
-                  "duration_seconds": 255,
-                  "artists": None,
-                  "album": {
-                    "name": "18 Months",
-                    "id": "FEmusic_library_privately_owned_release_detailb_po_55chars"
-                  },
-                  "likeStatus": "INDIFFERENT",
-                  "thumbnails": None
-                },
+        :return: Album with title, description, artist and tracks,
+            see :py:class:`ytmusicapi.models.uploads.UploadAlbum`
         """
         self._check_auth()
         body = {"browseId": browseId}
         endpoint = "browse"
         response = self._send_request(endpoint, body)
-        album = parse_album_header(response)
-        results = nav(response, SINGLE_COLUMN_TAB + SECTION_LIST_ITEM + MUSIC_SHELF)
-        album["tracks"] = parse_uploaded_items(results["contents"])
-        album["duration_seconds"] = sum_total_duration(album)
-        return album
+        return parse_upload_album(response)
 
     def upload_song(self, filepath: str) -> ResponseStatus | requests.Response:
         """

--- a/ytmusicapi/models/__init__.py
+++ b/ytmusicapi/models/__init__.py
@@ -1,4 +1,5 @@
 from .base import YTMusicModel
 from .lyrics import LyricLine, Lyrics, TimedLyrics
+from .uploads import UploadAlbum, UploadSong
 
-__all__ = ["LyricLine", "Lyrics", "TimedLyrics", "YTMusicModel"]
+__all__ = ["LyricLine", "Lyrics", "TimedLyrics", "UploadAlbum", "UploadSong", "YTMusicModel"]

--- a/ytmusicapi/models/uploads.py
+++ b/ytmusicapi/models/uploads.py
@@ -1,0 +1,59 @@
+"""Response models for the upload-library methods.
+
+Uploaded items are similar to but not the same as regular songs: they carry an
+``entityId`` and lack several fields YTM-hosted songs have. Until the song model
+from #983 and the shared leaf models from #981 land, the shapes are modelled
+here; the leaves deliberately match #981 so they can be re-homed onto the
+shared models without touching callers.
+"""
+
+from .base import YTMusicModel
+from .content.enums import LikeStatus
+
+
+class Thumbnail(YTMusicModel):
+    url: str
+    width: int | None = None
+    height: int | None = None
+
+
+class ArtistRef(YTMusicModel):
+    name: str | None = None
+    id: str | None = None
+
+
+class AlbumRef(YTMusicModel):
+    name: str | None = None
+    id: str | None = None
+
+
+class UploadSong(YTMusicModel):
+    """An uploaded song, as returned by the upload-library methods."""
+
+    entityId: str
+    videoId: str
+    title: str | None = None
+    duration: str | None = None
+    duration_seconds: int | None = None
+    artists: list[ArtistRef]
+    album: AlbumRef | None = None
+    likeStatus: LikeStatus
+    thumbnails: list[Thumbnail] | None = None
+
+
+class UploadAlbum(YTMusicModel):
+    """An uploaded album with its tracks, as returned by ``get_library_upload_album``."""
+
+    title: str
+    type: str
+    thumbnails: list[Thumbnail] | None = None
+    isExplicit: bool
+    description: str | None = None
+    artists: list[ArtistRef] | None = None
+    year: str | None = None
+    trackCount: int | None = None
+    duration: str
+    audioPlaylistId: str | None = None
+    likeStatus: LikeStatus | None = None
+    tracks: list[UploadSong]
+    duration_seconds: int

--- a/ytmusicapi/parsers/uploads.py
+++ b/ytmusicapi/parsers/uploads.py
@@ -1,10 +1,13 @@
-from ytmusicapi.type_alias import JsonList
+from ytmusicapi.helpers import sum_total_duration
+from ytmusicapi.models.uploads import AlbumRef, ArtistRef, UploadAlbum, UploadSong
+from ytmusicapi.type_alias import JsonDict, JsonList
 
 from ._utils import *
+from .albums import parse_album_header
 from .songs import parse_song_album, parse_song_artists
 
 
-def parse_uploaded_items(results: JsonList) -> JsonList:
+def parse_uploaded_items(results: JsonList) -> list[UploadSong]:
     songs = []
     for result in results:
         data = result[MRLIR]
@@ -35,18 +38,26 @@ def parse_uploaded_items(results: JsonList) -> JsonList:
         duration = None
         if "fixedColumns" in data:
             duration = nav(get_fixed_column_item(data, 0), TEXT_RUN_TEXT)
-        song = {
-            "entityId": entityId,
-            "videoId": videoId,
-            "title": title,
-            "duration": duration,
-            "duration_seconds": parse_duration(duration),
-            "artists": parse_song_artists(data, 1),
-            "album": parse_song_album(data, 2),
-            "likeStatus": like,
-            "thumbnails": thumbnails,
-        }
+        song = UploadSong(
+            entityId=entityId,
+            videoId=videoId,
+            title=title,
+            duration=duration,
+            duration_seconds=parse_duration(duration),
+            artists=[ArtistRef(**artist) for artist in parse_song_artists(data, 1)],
+            album=AlbumRef(**album) if (album := parse_song_album(data, 2)) else None,
+            likeStatus=like,
+            thumbnails=thumbnails,
+        )
 
         songs.append(song)
 
     return songs
+
+
+def parse_upload_album(response: JsonDict) -> UploadAlbum:
+    album = parse_album_header(response)
+    results = nav(response, SINGLE_COLUMN_TAB + SECTION_LIST_ITEM + MUSIC_SHELF)
+    album["tracks"] = parse_uploaded_items(results["contents"])
+    album["duration_seconds"] = sum_total_duration(album)
+    return UploadAlbum(**album)


### PR DESCRIPTION
## Summary

- `get_library_upload_songs`, `get_library_upload_artist` and `get_library_upload_album` now return pydantic response models (`UploadSong`, `UploadAlbum`) deriving from the `YTMusicModel` base landed in #1004
- parsing lives in `ytmusicapi/parsers/uploads.py`: `parse_uploaded_items` constructs `UploadSong` directly, and a new `parse_upload_album` assembles the album header plus tracks
- docstrings point at the models instead of repeating the JSON shape
- `get_continuations` / `get_continuation_contents` take a TypeVar so a parse func returning models typechecks; the dict parse funcs everywhere else are unchanged

Closes #987

## Why

uploaded items are similar to but not the same as regular songs: they carry an `entityId` and lack several fields YTM-hosted songs have (`isAvailable`, `videoType`, `setVideoId`). since the song model from #983 and the shared leaf models from #981 are not merged yet, these are upload-specific models for now. the leaf shapes (`Thumbnail`, `ArtistRef`, `AlbumRef`) deliberately match what #981 plans, so re-homing them onto the shared models later is mostly a rename.

one behavioural note for 2.0 consumers: with the #307 key-presence semantics, a field the API did not return is present with value `None` instead of being absent. `"album" in song` is `True` even when the song has no album column, and `song["album"]` returns `None` instead of raising. dict-style access (`song["title"]`, `song.get("entityId")`) keeps working through the mapping protocol, so code like the existing `tests/mixins/test_uploads.py` flows is unaffected.

## Verification

- `pytest -o addopts='' tests/parsers tests/models -q`: 103 passed. new tests in `tests/parsers/test_uploads.py` cover: full song parse, missing fixedColumns / album column / thumbnails staying present as `None`, unknown likeStatus falling back to `INDIFFERENT`, menu-less items skipped, a continuation page parsed through the model parse func, and album `duration_seconds` summed over tracks (4:15 => 255, two tracks => 510)
- `mypy` (strict, repo config), clean
- `ruff check .` and `ruff format --check .`: clean
- the live tests in `tests/mixins/test_uploads.py` are unchanged and run in CI with the repo credentials
